### PR TITLE
(can_util) Fixing marti_can_msgs dependency.

### DIFF
--- a/can_util/CMakeLists.txt
+++ b/can_util/CMakeLists.txt
@@ -20,6 +20,7 @@ include(${build_tools_PACKAGE_PATH}/scripts/build_common.cmake)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_executable(can_bus_example src/nodes/can_bus_example.cpp)
+add_dependencies(can_bus_example marti_can_msgs_generate_messages_cpp)
 target_link_libraries(can_bus_example ${catkin_LIBRARIES})
 
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
NOTE:  This commit should be merged into the catkin-based branches.