### PR TITLE
Fixing a few typos in CMake macros.

### DIFF
--- a/build_tools/scripts/log_version.cmake
+++ b/build_tools/scripts/log_version.cmake
@@ -11,7 +11,7 @@ if(_not_git)
     #Try SVN
     execute_process(COMMAND svnversion
         OUTPUT_VARIABLE version_rev_string
-        OUTPUT_STRIP_TRAILING_WHITEPSACE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE _not_svn)
     execute_process(COMMAND svn status
         OUTPUT_VARIABLE version_status_string)

--- a/build_tools/scripts/version_file.cmake
+++ b/build_tools/scripts/version_file.cmake
@@ -11,7 +11,7 @@ if(_not_git)
     #Try SVN
     execute_process(COMMAND svnversion
         OUTPUT_VARIABLE version_rev_string
-        OUTPUT_STRIP_TRAILING_WHITEPSACE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE _not_svn)
     execute_process(COMMAND svn status
         OUTPUT_VARIABLE version_status_string)


### PR DESCRIPTION
These weren't actually hurting anything since they're in a conditional block that only runs if you're using SVN, but they were causing error messages in tools that parsed CMake files (like CLion).