### PR TITLE
Add required rosdeps to transform_util

### DIFF
--- a/transform_util/package.xml
+++ b/transform_util/package.xml
@@ -24,6 +24,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>math_util</depend>
   <depend>yaml_util</depend>
+  <depend>libgeos++-dev</depend>
+  <depend>proj</depend>
   
   <export>
     <transform_util plugin="${prefix}/transformer_plugins.xml" />


### PR DESCRIPTION
Building the `transform_util` package requires GEOS and proj.4. This PR adds them to the list of dependencies.