### PR TITLE
Indigo devel

### DIFF
--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -5,6 +5,7 @@ project(swri_geometry_util)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   cmake_modules
+  tf
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -16,7 +17,9 @@ find_package(OpenCV REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp
+  CATKIN_DEPENDS
+    roscpp
+    tf
 )
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS} ${GEOS_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIRS})

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
 ) 
 
 find_package(OpenCV REQUIRED)
+find_package(Boost REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
@@ -32,7 +33,7 @@ catkin_package(
     swri_yaml_util
 )
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} 
   src/georeference.cpp

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -14,18 +14,22 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
-  <depend>roscpp</depend>
-  <depend>rospy</depend>
-  <depend>tf</depend>
-  <depend>pluginlib</depend>
-  <depend>topic_tools</depend>
+  <depend>boost</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>gps_common</depend>
-  <depend>diagnostic_msgs</depend>
+  <depend>libgeos++-dev</depend>
+  <depend>libopencv-dev</depend>
+  <depend>pluginlib</depend>
+  <depend>proj</depend>
+  <depend>roscpp</depend>
+  <depend>rospy</depend>
   <depend>swri_math_util</depend>
   <depend>swri_yaml_util</depend>
-  <depend>libgeos++-dev</depend>
-  <depend>proj</depend>
+  <depend>tf</depend>
+  <depend>topic_tools</depend>
+  <depend>yaml-cpp</depend>
+
   <test_depend>rostest</test_depend>
   
   <export>

--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -20,7 +20,7 @@ else( ${YamlCpp_VERSION} MATCHES "0.[23].*")
 endif( ${YamlCpp_VERSION} MATCHES "0.[23].*")
 configure_file(version.h.in ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/version.h)
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${YamlCpp_INCLUDE_DIR})
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${YamlCpp_INCLUDE_DIR})
 
 add_library(${PROJECT_NAME}
   src/yaml_util.cpp


### PR DESCRIPTION
Fixes for #237, #238, #239, and #240.

Hopefully this is all that's left to get swri_geometry_util, swri_transform_util, and swri_yaml_util to compile on the ROS build farm. I'll close those issues as soon as those packages build successfully there.