### PR TITLE
Closes #269.

### DIFF
--- a/swri_roscpp/CMakeLists.txt
+++ b/swri_roscpp/CMakeLists.txt
@@ -4,13 +4,19 @@ project(swri_roscpp)
 
 set(BUILD_DEPS
   diagnostic_updater 
-  nav_msgs 
-  roscpp)
+  nav_msgs
+  roscpp
+  std_msgs
+  std_srvs
+)
 
 set(RUNTIME_DEPS
   diagnostic_updater 
   nav_msgs 
-  roscpp)
+  roscpp
+  std_msgs
+  std_srvs
+)
 
 ### Catkin ###
 find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})

--- a/swri_roscpp/package.xml
+++ b/swri_roscpp/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <package format="2">
   <name>swri_roscpp</name>
-  <version>1.0.0</version>
+  <version>0.0.0</version>
   <description>
 
      swri_roscpp
@@ -13,6 +13,8 @@
   <depend>diagnostic_updater</depend>
   <depend>nav_msgs</depend>
   <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <export/>
 </package>
 


### PR DESCRIPTION
Adds missing std_srvs and std_msgs packages to swri_roscpp.