### PR TITLE
Installing the initialize_origin.py node.

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -83,6 +83,10 @@ install(TARGETS ${PROJECT_NAME} lat_lon_tf_echo transformer_plugins
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
 
+### Install Python Nodes/Scripts ###
+catkin_install_python(PROGRAMS nodes/initialize_origin.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
 install(FILES transformer_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
The initialize_origin.py node in swri_transform_utils was previously not being installed.  Now it is.