### PR TITLE
Adds a GetTF method to transform_util::Transform.

### DIFF
--- a/transform_util/include/transform_util/transform.h
+++ b/transform_util/include/transform_util/transform.h
@@ -162,6 +162,12 @@ namespace transform_util
     tf::Quaternion operator*(const tf::Quaternion& q) const;
 
     /**
+     * Return a TF transform equivalent to this transform
+     * @return The equivalent tf::Transform
+     */
+    tf::Transform GetTF() const;
+
+    /**
      * Return the inverse transform.
      *
      * @returns The inverse transform.

--- a/transform_util/src/transform.cpp
+++ b/transform_util/src/transform.cpp
@@ -106,6 +106,11 @@ namespace transform_util
     return transform_->GetOrientation();
   }
 
+  tf::Transform Transform::GetTF() const
+  {
+    return tf::Transform(GetOrientation(),GetOrigin());
+  }
+
   void IdentityTransform::Transform(const tf::Vector3& v_in, tf::Vector3& v_out) const
   {
     v_out = v_in;


### PR DESCRIPTION
tf::Transforms can do a lot of things that transform_util::Transforms can't, so sometimes it's convenient to just get a tf::Transform.