### PR TITLE
Fix bugs in FitRigidTransform2d.

### DIFF
--- a/opencv_util/include/opencv_util/model_fit.h
+++ b/opencv_util/include/opencv_util/model_fit.h
@@ -125,6 +125,7 @@ namespace opencv_util
     int32_t max_iterations = 1000,
     math_util::RandomGeneratorPtr rng = math_util::RandomGeneratorPtr());
     
+  // Returns a 2x3 transform that can be applied to points1 to align them to points2.
   cv::Mat FitRigidTransform2d(const cv::Mat& points1, const cv::Mat& points2);
   
   cv::Mat FindAffineTransform2d(

--- a/opencv_util/src/model_fit.cpp
+++ b/opencv_util/src/model_fit.cpp
@@ -87,11 +87,11 @@ namespace opencv_util
     cv::Mat points2_centered = (points2 - centroid2);
     
     // Reshape the points into 2xN matrices.
-    points1_centered = points1_centered.reshape(1, 2);
-    points2_centered = points2_centered.reshape(1, 2);
+    points1_centered = points1_centered.reshape(1, points1.rows);
+    points2_centered = points2_centered.reshape(1, points1.rows);
     
     // Compute the covariance matrix.
-    cv::Mat cov = points1_centered * points2_centered.t();
+    cv::Mat cov = points1_centered.t() * points2_centered;
     
     // Compute the optimal rotation matrix.
     cv::Mat W, U, Vt;
@@ -100,7 +100,6 @@ namespace opencv_util
     cv::Mat I = cv::Mat::eye(2, 2, CV_32F);
     I.at<float>(1, 1) = d;
     cv::Mat rotation = Vt.t() * I * U.t();
-    rotation = rotation.inv();
     
     // Compute the optimal translation.
     cv::Mat c1_r(2, 1, CV_32F);


### PR DESCRIPTION
The main problem was that reshape was being incorrectly, causing the
points to get shuffled around.  Once that was fixed, it was clear that
the rotation should not be inverted.  Also added a comment to clarify
the significance of the returned transform.