### PR TITLE
Making swri::ServiceServer's = return a value.

### DIFF
--- a/swri_roscpp/include/swri_roscpp/service_server.h
+++ b/swri_roscpp/include/swri_roscpp/service_server.h
@@ -170,6 +170,7 @@ ServiceServer& ServiceServer::operator=(const ServiceServer &other)
   impl_ = other.impl_;
   impl_->setInstrumentPerClient(instrument_per_client);
   impl_->setLogCalls(log_calls);
+  return *this;
 }
 
 inline


### PR DESCRIPTION
swri::ServiceServer's assignment operator was not returning a value.  This
is technically legal, and GCC will do the right thing for you, which is
to return a reference to the current object.  Clang, however, will
compile the code but generate a SIGILL exception at runtime.  This is
easily fixed by manually returning *this.