### PR TITLE
Returning a value from swri::Subscriber::blockTimeouts

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -367,7 +367,7 @@ void Subscriber::setTimeout(const double time_out)
 inline
 bool Subscriber::blockTimeouts(bool block)
 {
-  impl_->blockTimeouts(block);
+  return impl_->blockTimeouts(block);
 }
 
 inline


### PR DESCRIPTION
The swri::Subscriber::blockTimeouts function had a return type but
was not explicitly returning a value.  This behavior is undefined.
It's simply chaining a call to a different blockTimeouts function, so
I made it return that.