### PR TITLE
Fixes a typo in cmake_modules package name.

### DIFF
--- a/swri_geometry_util/package.xml
+++ b/swri_geometry_util/package.xml
@@ -12,7 +12,7 @@
   <url>https://github.com/swri-robotics/marti_common</url>
   
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>cmake-modules</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <depend>eigen</depend>
   <depend>libgeos++-dev</depend>
   <depend>libopencv-dev</depend>

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>camera_calibration_parsers</depend>
-  <build_depend>cmake-modules</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <depend>cv_bridge</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
Pull request #298 introduced a build failure because cmake_modules was spelled as cmake-modules.
Refs #296