### PR TITLE
Add swri_route_util package.

### DIFF
--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(swri_route_util)
+
+set(BUILD_DEPS 
+  marti_nav_msgs
+  roscpp
+  swri_transform_util
+  )
+
+set(RUNTIME_DEPS ${BUILD_DEPS})
+
+
+### Catkin ###
+find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
+include_directories(${catkin_INCLUDE_DIRS})
+catkin_package(CATKIN_DEPENDS ${RUNTIME_DEPS}
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME})
+
+include_directories(include)
+
+### Build Library ###
+add_library(${PROJECT_NAME} 
+  src/route.cpp
+  src/route_point.cpp
+  src/util.cpp
+  )
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-std=c++0x")
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+### Install Libraries and Executables ###
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+### Install Header Files ###
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+

--- a/swri_route_util/include/swri_route_util/route.h
+++ b/swri_route_util/include/swri_route_util/route.h
@@ -1,0 +1,180 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#ifndef SWRI_ROUTE_UTIL_ROUTE_H_
+#define SWRI_ROUTE_UTIL_ROUTE_H_
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include <boost/lexical_cast.hpp>
+
+#include <marti_nav_msgs/Route.h>
+#include <swri_route_util/route_point.h>
+
+namespace swri_route_util
+{
+// The Route class provides a more friendly interface for working with
+// the marti_nav_msgs::Route message.  It provides native access to
+// known properties and supports fast lookups of points by their ids.
+//
+// This class is optimized for a combination of simplicity, nice
+// syntax, and performance for standard use cases.  This means that
+// some tradeoffs were made for less common use cases.
+//
+// In particular, findPointId() may take a long time when called with
+// ids that do not exist in the route because of the behind-the-scenes
+// caching.  If this is an important use case and you are ABSOLUTELY
+// sure that the points list has not been modified since the class was
+// created from a message, you can avoid this performance hit by
+// calling findPointIdConst() instead.
+class Route
+{
+ public:
+  // Create a new empty route.
+  Route();
+
+  // Create a route from an existing marti_nav_msgs::Route message.
+  // Warning: If a route or a specific route point contains properties
+  // with duplicate keys, only one will be kept; the others are
+  // silently discarded.  Don't use non-unique property keys.
+  Route(const marti_nav_msgs::Route &msg);
+
+  // Create a marti_nav_msgs::Route from the route, in place version.
+  void toMsg(marti_nav_msgs::Route &msg) const;
+  // Create a marti_nav_msgs::Route from the route, returned as a
+  // shared pointer.
+  marti_nav_msgs::RoutePtr toMsgPtr() const;
+
+  // The header of the route. This is exposed as field to be
+  // consistent with typical ROS style.
+  std_msgs::Header header;
+
+  // The points of the route.  This is exposed as a field because it's
+  // much simpler (for me to write and you to use) than trying to
+  // replicate the entire vector interface.
+  std::vector<RoutePoint> points;
+
+  // A route is considered invalid if it has no points.
+  bool valid() const;
+  
+  // Find a point index by its ID.  For the common use case of looking
+  // up valid ids in a static route, this will be very fast.  For less
+  // common cases like looking up valid ids in a route that has been
+  // modified, it may be slower.  It is the slowest when looking up
+  // many invalid ids in any route.  If there are multiple points with
+  // the requested key, it will return one of the points, but which
+  // one is undefined.  Don't use non-unqiue ids.
+  bool findPointId(size_t &index, const std::string &id) const;
+
+  // Find a point index by its ID, the less safe version.  This
+  // version should only be used on Routes with a valid internal index
+  // (rebuildPointIndex() was called and points were never added,
+  // removed, reordered, or changed ids).  This version will not
+  // rebuild the internal point index if an id is not found, so it is
+  // much faster for repeated invalid lookups.  If the "static"
+  // assumption is violated, this version may incorrectly miss a valid
+  // id.  It will never return a point with a different id than
+  // requested.  Be sure you know what you're doing if you want to use
+  // this.
+  bool findPointIdConst(size_t &index, const std::string &id) const;
+
+  // Rebuilds the internal point index.  This is handled internally
+  // and exposed for very special use cases, which you probably do not
+  // need.  Be sure you know what you're doing if you want to use this.
+  void rebuildPointIndex() const;
+
+  // Native access to the route "name" property, which is required to
+  // exist.
+  std::string name() const;
+  void setName(const std::string &name);
+
+  // Native access to the route "guid" property, which is required to
+  // exist.
+  std::string guid() const;
+  void setGuid(const std::string &guid);
+
+  // The following methods provide general purpose access to route
+  // properties.  They will also correctly map to properties that are
+  // exposed natively.  Native methods (e.g.  name(), guid()) are
+  // generally faster and safer and should be preferred when
+  // available.
+
+  // Get a list of all the properties defined for this route,
+  // including native properties.
+  std::vector<std::string> getPropertyNames() const;
+
+  // Get the value of a property.  Returns an empty string if the
+  // property does not exist.
+  std::string getProperty(const std::string &name) const;
+  template <typename T>
+
+  // Get the value of a property, lexically cast to a known type.
+  // Returns the lexical cast of an empty string if the property does
+  // not exist..
+  T getTypedProperty(const std::string &name) const;
+
+  // Determine if the specified property is defined for the route.
+  bool hasProperty(const std::string &name) const;
+
+  // Set the value of a property.  If the property doesn't exist, it
+  // is added.
+  void setProperty(const std::string &name, const std::string &value);
+
+  // Delete a property.  If the property doesn't exist or is not
+  // deletable (e.g. name, guid), this method does nothing.
+  void deleteProperty(const std::string &name);
+
+ private:
+  // The point index maps point ids to their index in the points
+  // vector.  It is mutable because we want to support fast look ups
+  // on const Routes.
+  mutable std::map<std::string, size_t> point_index_;
+
+  // Map containing generic properties.
+  std::map<std::string, std::string> properties_;
+
+  // Storage for native properties.
+  std::string guid_;
+  std::string name_;
+};  // class Route
+
+// Typedef shared pointers to make migrating from the message types to
+// this interface more convenient.
+typedef boost::shared_ptr<Route> RoutePtr;
+typedef boost::shared_ptr<Route const> RouteConstPtr;
+
+template<typename T>
+inline
+T Route::getTypedProperty(const std::string &name) const
+{
+  return boost::lexical_cast<T>(getProperty(name));
+}
+} // namespace swri_route_util
+#endif  // SWRI_ROUTE_UTIL_ROUTE_H_

--- a/swri_route_util/include/swri_route_util/route_point.h
+++ b/swri_route_util/include/swri_route_util/route_point.h
@@ -1,0 +1,125 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#ifndef SWRI_ROUTE_UTIL_ROUTE_POINT_H_
+#define SWRI_ROUTE_UTIL_ROUTE_POINT_H_
+
+#include <string>
+#include <map>
+
+#include <tf/tf.h>
+
+namespace swri_route_util
+{
+// The RoutePoint class provides a more friendly interface for working
+// with the marti_nav_msgs::Route and marti_nav_msgs::RoutePoint
+// message types.  See comments for swri_route_util::RoutePoint for
+// more information.  This class is used to represent both route
+// points that are part of a Route, and independent points that were
+// interpolated from a Route.
+class RoutePoint
+{
+ public:
+  // Access to the route point's position as tf datatypes.
+  void setPosition(const tf::Vector3 &position);
+  const tf::Vector3& position() const;
+  tf::Vector3& position();
+
+  // Access to the route point's position as message datatypes.
+  void setPosition(const geometry_msgs::Point &position);
+  const geometry_msgs::Point positionMsg() const;
+
+  // Access to the route point's orientation as tf datatypes.
+  void setOrientation(const tf::Quaternion &orientation);
+  const tf::Quaternion& orientation() const;
+  tf::Quaternion& orientation();
+
+  // Access to the route point's orientation as message datatypes.
+  void setOrientation(const geometry_msgs::Quaternion &orientation);
+  const geometry_msgs::Quaternion orientationMsg() const;
+
+  // Access to the route point's pose (position and orientation) as
+  // tf datatypes.
+  void setPose(const tf::Pose &pose);
+  tf::Pose pose() const;
+
+  // Access to the route point's pose (position and orientation) as
+  // message datatypes.
+  void setPose(const geometry_msgs::Pose &pose);
+  geometry_msgs::Pose poseMsg() const;
+
+  // Access to the route point's id.  Ids should be unique when used,
+  // but are typically not set for interpolated points.
+  const std::string& id() const;
+  void setId(const std::string &id);
+
+  // The following methods provide general purpose access to route
+  // point properties.  They will also correctly map to properties
+  // that are exposed natively.  Native methods are generally faster
+  // and safer and should be preferred when available.  Note: We have
+  // not yet added any native properties for the route point.
+
+  // Get a list of all the properties defined for this route point,
+  // including native properties.
+  std::vector<std::string> getPropertyNames() const;
+  
+  // Get the value of a property.  Returns an empty string if the
+  // property does not exist.
+  std::string getProperty(const std::string &name) const;
+
+  // Get the value of a property, lexically cast to a known type.
+  // Returns the lexical cast of an empty string if the property does
+  // not exist..
+  template <typename T>
+  T getTypedProperty(const std::string &name) const;
+
+  // Determine if the specified property is defined for the route
+  // point.
+  bool hasProperty(const std::string &name) const;
+
+  // Set the value of a property.  If the property doesn't exist, it
+  // is added.
+  void setProperty(const std::string &name, const std::string &value);
+
+  // Delete a property.  If the property doesn't exist or is not
+  // deletable (e.g. name, guid), this method does nothing.
+  void deleteProperty(const std::string &name);
+  
+ private:
+  tf::Vector3 position_;
+  tf::Quaternion orientation_;
+
+  std::string id_;
+
+  std::map<std::string, std::string> properties_;
+};  // class RoutePoint
+} // namespace swri_route_util
+
+#include "route_point_inline.h"
+
+#endif  // SWRI_ROUTE_UTIL_ROUTE_POINT_H_

--- a/swri_route_util/include/swri_route_util/route_point_inline.h
+++ b/swri_route_util/include/swri_route_util/route_point_inline.h
@@ -1,0 +1,151 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#ifndef SWRI_ROUTE_UTIL_ROUTE_POINT_INLINE_H_
+#define SWRI_ROUTE_UTIL_ROUTE_POINT_INLINE_H_
+
+#include <boost/lexical_cast.hpp>
+
+namespace swri_route_util
+{
+inline
+void RoutePoint::setPosition(const tf::Vector3 &position)
+{
+  position_ = position;
+}
+
+inline
+const tf::Vector3& RoutePoint::position() const
+{
+  return position_;
+}
+
+inline
+tf::Vector3& RoutePoint::position()
+{
+  return position_;
+}
+
+inline
+void RoutePoint::setPosition(const geometry_msgs::Point &position)
+{
+  tf::pointMsgToTF(position, position_);
+}
+
+inline
+const geometry_msgs::Point RoutePoint::positionMsg() const
+{
+  geometry_msgs::Point p;
+  tf::pointTFToMsg(position_, p);
+  return p;
+}
+
+inline
+void RoutePoint::setOrientation(const tf::Quaternion &orientation)
+{
+  orientation_ = orientation;
+}
+
+inline
+const tf::Quaternion& RoutePoint::orientation() const
+{
+  return orientation_;
+}
+
+inline
+tf::Quaternion& RoutePoint::orientation()
+{
+  return orientation_;
+}
+
+inline
+void RoutePoint::setOrientation(const geometry_msgs::Quaternion &orientation)
+{
+  tf::quaternionMsgToTF(orientation, orientation_);
+}
+
+inline
+const geometry_msgs::Quaternion RoutePoint::orientationMsg() const
+{
+  geometry_msgs::Quaternion q;
+  tf::quaternionTFToMsg(orientation_, q);
+  return q;
+}
+
+inline
+void RoutePoint::setPose(const tf::Pose &pose)
+{
+  setPosition(pose.getOrigin());
+  setOrientation(pose.getRotation());
+}
+
+inline
+tf::Pose RoutePoint::pose() const
+{
+  tf::Pose pose;
+  pose.setOrigin(position_);
+  pose.setRotation(orientation_);
+  return pose;
+}
+
+inline
+void RoutePoint::setPose(const geometry_msgs::Pose &pose)
+{
+  setPosition(pose.position);
+  setOrientation(pose.orientation);
+}
+
+inline
+geometry_msgs::Pose RoutePoint::poseMsg() const
+{
+  geometry_msgs::Pose pose;
+  pose.position = positionMsg();
+  pose.orientation = orientationMsg();
+  return pose;
+}
+  
+inline
+const std::string& RoutePoint::id() const
+{
+  return id_;
+}
+
+inline
+void RoutePoint::setId(const std::string &id)
+{
+  id_ = id;
+}
+
+template <typename T>
+inline
+T RoutePoint::getTypedProperty(const std::string &name) const
+{
+  return boost::lexical_cast<T>(getProperty(name));
+}
+} // namespace swri_route_util
+#endif  // SWRI_ROUTE_UTIL_ROUTE_POINT_INLINE_H_

--- a/swri_route_util/include/swri_route_util/util.h
+++ b/swri_route_util/include/swri_route_util/util.h
@@ -1,0 +1,105 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#ifndef SWRI_ROUTE_UTIL_UTIL_H_
+#define SWRI_ROUTE_UTIL_UTIL_H_
+
+#include <marti_nav_msgs/RoutePosition.h>
+#include <swri_transform_util/transform.h>
+
+namespace swri_route_util
+{
+class Route;
+class RoutePoint;
+
+// Transform a route.  The route will be transformed in place using
+// the supplied transform.  Known property types that are affected by
+// the transform are expceted to be transformed properly.  The
+// frame_id of the transformed route will be set to the required
+// target_frame argument, because forgetting to up the frame_id has
+// caused difficult bugs several times.
+void transform(Route &route,
+               const swri_transform_util::Transform &transform,
+               const std::string &target_frame);
+
+
+// Project a route to the XY plane by setting the Z coordinate to zero.
+void projectToXY(Route &route);
+
+
+// Fill in the orientation of the route points using an estimate from
+// the route geometry and desired "up" direction.  This function
+// assumes the route is in a cartesian (e.g. not WGS84) frame.
+void fillOrientations(Route &route,
+                      const tf::Vector3 &up=tf::Vector3(0.0, 0.0, 1.0));
+
+
+// Find the closest point on the route (as a route position) for a
+// given point.  If extrapolate_before_start and/or
+// extrapolate_past_end are true, the projection will consider the
+// first and last segments to extend infinitely (ONLY if the point is
+// nearest to either without extrapolation).  This function assumes
+// the route is in a cartesian (e.g. not WGS84) frame.
+bool projectOntoRoute(marti_nav_msgs::RoutePosition &position,
+                      const Route &route,
+                      const tf::Vector3 &point,
+                      bool extrapolate_before_start,
+                      bool extrapolate_past_end);
+
+
+// Normalize a route position.  A normalize route position is guaranteed to
+// have:
+//   - A valid id for a point in the route.
+//   
+//   - If the position is before the start of the route, the id will be
+//     first route point and the distance will be negative.
+
+//   - If the position is after the end of the route, the id will be the
+//     last route point and the distance will be positive.
+//
+//   - Otherwise, the position's id will be for the point that begins
+//     the segment containing the position, and the distance will be
+//     less than that length of that segment.
+//
+//  This function fails the original position's id is not found in the
+// route.  This function assumes the route is in a cartesian (e.g. not
+// WGS84) frame.
+bool normalizeRoutePosition(marti_nav_msgs::RoutePosition &normalized_position,
+                            const Route &route,
+                            const marti_nav_msgs::RoutePosition &position);
+
+
+// Create a route point from a route position by interpolating between
+// the route's points as needed.  This function assumes the route is
+// in a cartesian (e.g. not WGS84) frame.
+bool interpolateRoutePosition(RoutePoint &point,
+                              const Route &route,
+                              const marti_nav_msgs::RoutePosition &position,
+                              bool allow_extrapolation);
+}  // namespace swri_route_util
+#endif  // SWRI_ROUTE_UTIL_UTIL_H_

--- a/swri_route_util/package.xml
+++ b/swri_route_util/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>swri_route_util</name>
+  <version>0.0.1</version>
+
+  <description>
+    This library provides functionality to simplify working with the
+    navigation messages defined in marti_nav_msgs.
+  </description>
+
+  <maintainer email="elliot.johnson@swri.org">Elliot Johnson</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>marti_nav_msgs</depend>
+  <depend>roscpp</depend>
+  <depend>swri_transform_util</depend>
+
+  <export>
+  </export>
+</package>

--- a/swri_route_util/src/route.cpp
+++ b/swri_route_util/src/route.cpp
@@ -1,0 +1,244 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#include <swri_route_util/route.h>
+#include <swri_route_util/route_point.h>
+#include <boost/make_shared.hpp>
+
+namespace mnm = marti_nav_msgs;
+
+namespace swri_route_util
+{
+Route::Route()
+{
+}
+
+// Helper function used by the Route(mnm::Route) constructor.
+static
+void pointFromMsg(RoutePoint &dst, const marti_nav_msgs::RoutePoint &src)
+{
+  dst.setPose(src.pose);
+  dst.setId(src.id);
+
+  for (auto const &prop : src.properties) {
+    dst.setProperty(prop.key, prop.value);
+  }
+}
+
+Route::Route(const mnm::Route &msg)
+{
+  header = msg.header;
+
+  points.resize(msg.route_points.size());
+  for (size_t i = 0; i < points.size(); ++i) {
+    pointFromMsg(points[i], msg.route_points[i]);
+  }
+
+  for (auto const &prop : msg.properties) {
+    setProperty(prop.key, prop.value);
+  }
+
+  rebuildPointIndex();
+}
+
+// Helper method used by the toMsg() method.
+static
+void msgFromPoint(marti_nav_msgs::RoutePoint &dst, const RoutePoint &src)
+{
+  dst.pose = src.poseMsg();
+  dst.id = src.id();
+  
+  std::vector<std::string> names = src.getPropertyNames();
+  dst.properties.resize(names.size());
+  for (size_t i = 0; i < names.size(); ++i) {
+    dst.properties[i].key = names[i];
+    dst.properties[i].value = src.getProperty(names[i]);
+  }
+}
+
+void Route::toMsg(mnm::Route &msg) const
+{
+  msg.header = header;  
+
+  msg.route_points.resize(points.size());
+  for (size_t i = 0; i < points.size(); ++i) {
+    msgFromPoint(msg.route_points[i], points[i]);
+  }
+  
+  std::vector<std::string> names = getPropertyNames();
+  msg.properties.resize(names.size());
+  for (size_t i = 0; i < names.size(); ++i) {
+    msg.properties[i].key = names[i];
+    msg.properties[i].value = getProperty(names[i]);
+  }  
+}
+
+mnm::RoutePtr Route::toMsgPtr() const
+{
+  mnm::RoutePtr ptr = boost::make_shared<mnm::Route>();
+  toMsg(*ptr);
+  return ptr;
+}
+
+bool Route::valid() const
+{
+  return !points.empty();
+}
+
+bool Route::findPointId(size_t &index, const std::string &id) const
+{
+  if (point_index_.count(id)) {
+    size_t i = point_index_.at(id);
+    if (i < points.size() && points[i].id() == id) {
+      // This is a cache hit!
+      index = i;
+      return true;
+    }
+
+    // This is cache miss... our cache is out of date.
+  }
+
+  // If we reach here, either our cache is out of date or the point
+  // doesn't exist in the cache.  We will rebuild the cache index to
+  // make sure it is current.
+  rebuildPointIndex();
+
+  if (point_index_.count(id)) {
+    // If the point was found, we expect the id to be valid (unless
+    // you're using this class from multiple threads, which is not
+    // supported.
+    index = point_index_.at(id);
+    return true;
+  }
+
+  // The point does not exist in this route.
+  return false;
+}
+
+bool Route::findPointIdConst(size_t &index, const std::string &id) const
+{
+  if (point_index_.count(id)) {
+    size_t i = point_index_.at(id);
+    if (i < points.size() && points[i].id() == id) {
+      // This is a cache hit!
+      index = i;
+      return true;
+    }
+    // This is cache miss... our cache is out of date.    
+  }
+
+  return false;
+}
+
+std::vector<std::string> Route::getPropertyNames() const
+{
+  std::vector<std::string> names;
+  names.push_back("name");
+  names.push_back("guid");
+
+  for (auto const &it : properties_) {
+    names.push_back(it.first);
+  }
+  
+  return names;
+}
+  
+std::string Route::getProperty(const std::string &name) const
+{
+  if (name == "name") {
+    return name_;
+  } else if (name == "guid") {
+    return guid_;
+  } else if (properties_.count(name)) {
+    return properties_.at(name);
+  } else {
+    return "";
+  }
+}
+
+bool Route::hasProperty(const std::string &name) const
+{
+  if (name == "name") {
+    return true;
+  } else if (name == "guid") {
+    return true;
+  } else {
+    return properties_.count(name) > 0;
+  }
+}
+
+void Route::setProperty(const std::string &name, const std::string &value)
+{
+  if (name == "name") {
+    name_ = value;
+  } else if (name == "guid") {
+    guid_ = value;
+  } else {
+    properties_[name] = value;
+  } 
+}
+
+void Route::deleteProperty(const std::string &name)
+{
+  // If we add "native" properties that are erasable, we should check
+  // for those here first and mark them as deleted when appropriate.
+  
+  // Otherwise, fall back to the generic properties.
+  // std::map::erase() ignores the call if the key is not found.
+  properties_.erase(name);
+}
+
+std::string Route::name() const
+{
+  return name_;
+}
+
+void Route::setName(const std::string &name)
+{
+  name_ = name;
+}
+  
+std::string Route::guid() const
+{
+  return guid_;
+}
+
+void Route::setGuid(const std::string &guid)
+{
+  guid_ = guid;
+}
+
+void Route::rebuildPointIndex() const
+{
+  // Throw away the old index.
+  point_index_.clear();
+  for (size_t i = 0; i < points.size(); ++i) {
+    point_index_[points[i].id()] = i;
+  }
+}
+}  // namespace swri_route_util

--- a/swri_route_util/src/route_point.cpp
+++ b/swri_route_util/src/route_point.cpp
@@ -1,0 +1,91 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+#include <swri_route_util/route_point.h>
+
+namespace swri_route_util
+{
+std::vector<std::string> RoutePoint::getPropertyNames() const
+{
+  std::vector<std::string> names;
+  // Add native properties first.
+  // But we don't have any yet.
+  // names.push_back("name");
+
+  for (auto const &it : properties_) {
+    names.push_back(it.first);
+  }
+  
+  return names;
+}
+
+std::string RoutePoint::getProperty(const std::string &name) const
+{
+  // Check for native properties first.
+  // But we don't have any yet.
+  // if (name == "name") {
+  //   return name_;
+  // } else
+  if (properties_.count(name)) {
+    return properties_.at(name);
+  } else {
+    return "";
+  }
+}
+
+bool RoutePoint::hasProperty(const std::string &name) const
+{
+  // Check for native properties first.
+  // But we don't have any yet.
+  // if (name == "name") {
+  //   return true;
+  // } else
+  return properties_.count(name);
+}
+
+void RoutePoint::setProperty(const std::string &name, const std::string &value)
+{
+  // Check for native properties first.
+  // But we don't have any yet.
+  // if (name == "name") {
+  //   name_ = value;
+  // } else {
+    properties_[name] = value;
+  // }   
+}
+
+void RoutePoint::deleteProperty(const std::string &name)
+{
+  // If we add "native" properties that are erasable, we should check
+  // for those here first and mark them as deleted when appropriate.
+  
+  // Otherwise, fall back to the generic properties.
+  // std::map::erase() ignores the call if the key is not found.
+  properties_.erase(name);
+}
+}  // namespace swri_route_util


### PR DESCRIPTION
This commit adds a new package called swri_route_util that provides a
more user-friendly interface to the marti_nav_msgs Route and RoutePoint
classes, and a set of useful utilities.  At this point, most of the
code (except the properties) has been well tested on bag files.