### PR TITLE
Add native-ish ROS serialization support to sru::Route. (indigo)

### DIFF
--- a/swri_route_util/include/swri_route_util/route.h
+++ b/swri_route_util/include/swri_route_util/route.h
@@ -177,4 +177,7 @@ T Route::getTypedProperty(const std::string &name) const
   return boost::lexical_cast<T>(getProperty(name));
 }
 } // namespace swri_route_util
+
+#include "route_serializer.h"
+
 #endif  // SWRI_ROUTE_UTIL_ROUTE_H_

--- a/swri_route_util/include/swri_route_util/route_serializer.h
+++ b/swri_route_util/include/swri_route_util/route_serializer.h
@@ -1,0 +1,123 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <ros/message_traits.h>
+#include <ros/serialization.h>
+
+namespace ros
+{
+namespace message_traits
+{
+// http://wiki.ros.org/roscpp/Overview/MessagesSerializationAndAdaptingTypes
+// http://wiki.ros.org/roscpp/Overview/MessagesTraits
+
+// This type is not fixed-size.
+template<> struct IsFixedSize<swri_route_util::Route> : public FalseType {};
+// This type is memcpyable
+template<> struct IsSimple<swri_route_util::Route> : public TrueType {};
+// This type has a header
+template<> struct HasHeader<swri_route_util::Route> : public TrueType {};
+
+template<>
+struct MD5Sum<swri_route_util::Route>
+{
+  static const char* value()
+  {
+    // Ensure that if the definition of marti_nav_msgs::Route changes
+    // we have a compile error here.
+    ROS_STATIC_ASSERT(MD5Sum<marti_nav_msgs::Route>::static_value1 == 0x626dfe06202116afULL);
+    ROS_STATIC_ASSERT(MD5Sum<marti_nav_msgs::Route>::static_value2 == 0xac99e6de9fa42b3eULL);
+    return MD5Sum<marti_nav_msgs::Route>::value();
+  }
+
+  static const char* value(const swri_route_util::Route& m)
+  {
+    return MD5Sum<swri_route_util::Route>::value();
+  }
+};  // struct MD5Sum<swri_route_util::Route>
+
+template<>
+struct DataType<swri_route_util::Route>
+{
+  static const char* value()
+  {
+    return DataType<marti_nav_msgs::Route>::value();
+  }
+
+  static const char* value(const swri_route_util::Route& m)
+  {
+    return DataType<swri_route_util::Route>::value();
+  }
+};  // struct DataType<swri_route_util::Route>
+
+template<>
+struct Definition<swri_route_util::Route>
+{
+  static const char* value()
+  {
+    return Definition<marti_nav_msgs::Route>::value();
+  }
+
+  static const char* value(const swri_route_util::Route& m)
+  {
+    return Definition<swri_route_util::Route>::value();
+  }
+};  // struct Definition<swri_route_util::Route>
+}  // namespace message_traits
+
+namespace serialization
+{
+template<>
+struct Serializer<swri_route_util::Route>
+{
+  template<typename Stream>
+  inline static void write(Stream& stream, const swri_route_util::Route& route)
+  {
+    marti_nav_msgs::Route msg;
+    route.toMsg(msg);
+    stream.next(msg);
+  }
+
+  template<typename Stream>
+  inline static void read(Stream& stream, swri_route_util::Route& route)
+  {
+    marti_nav_msgs::Route msg;
+    stream.next(msg);
+    route = swri_route_util::Route(msg);
+  }
+
+  inline static uint32_t serializedLength(const swri_route_util::Route& route)
+  {
+    marti_nav_msgs::Route msg;
+    route.toMsg(msg);
+    return serializationLength(msg);
+  }
+};
+}  // namespace serialization
+}  // namespace ros

--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -248,17 +248,21 @@ void interpolateRouteSegment(
   double s;
   if (len > 1e-6) {
     s = distance / len;
-  } else if (distance < 0) {
-    // This is a degenerate case: If the points are too close together
-    // to define a numerically stable route point and the distance is
-    // negative, the interpolated value will be the first route point.
-    s = 0.0;
-  } else if (distance > 1) {
-    // This is a degenerate case: If the points are too close together
-    // to define a numerically stable route point and the distance is
-    // positive, the interpolated value will be the second route
-    // point.
-    s = 1.0;
+  } else {
+    // This is a degenerate case where the points are too close
+    // together to define a numerically stable route point.
+    if (distance < 0) {
+      // If the distance is negative, the interpolated value will be
+      // the first route point.
+      s = 0.0;
+    } else if (distance > 1) {
+      // If the distance is positive, the interpolated value will be
+      // the second route point.
+      s = 1.0;
+    } else {
+      // Otherwise just take the center of the two points.
+      s = 0.5;
+    }
   }
 
   dst.setPosition((1.0-s)*p0.position() + s*p1.position());


### PR DESCRIPTION
This commit adds native(-ish) ROS serialization support so that
swri_route_util::Route can be used directly with publishers and
subscribers. This is purely for convenience rather than performance
(although you will get improved performance in nodelets that
publish/subscribe by avoiding serialization).  Under the hood, the
implementation does serialization with the native type and then
converts it to/from the swri_route_util::Route type.

This commit also fixes a missing special case in
interpolateRouteSegment (0 < distance < 1) and reorganized the if/else
blocks to be clearer.