### PR TITLE
Add util functions to calculate distances between route points. (indigo)

### DIFF
--- a/swri_route_util/include/swri_route_util/util.h
+++ b/swri_route_util/include/swri_route_util/util.h
@@ -101,5 +101,26 @@ bool interpolateRoutePosition(RoutePoint &point,
                               const Route &route,
                               const marti_nav_msgs::RoutePosition &position,
                               bool allow_extrapolation);
+
+// Return the distance between two route positions.  This function
+// works for routes defined in WGS84 or Euclidean spaces.
+bool routeDistance(
+  double &distance,
+  const marti_nav_msgs::RoutePosition &start,
+  const marti_nav_msgs::RoutePosition &end,
+  const Route &route);
+
+// Return the distances between a start route position and multiple
+// end route positions.  This function works for routes defined in
+// WGS84 or Euclidean spaces.  This function returns false if the
+// start point wasn't found in the route, in which case distances is
+// not modified.  If the function is true, the start point was found
+// and distances is guaranteed to be the same size as ends.  If an end
+// point is not found in the route, its distance is set to NaN.
+bool routeDistances(
+  std::vector<double> &distances,
+  const marti_nav_msgs::RoutePosition &start,
+  const std::vector<marti_nav_msgs::RoutePosition> &ends,
+  const Route &route);
 }  // namespace swri_route_util
 #endif  // SWRI_ROUTE_UTIL_UTIL_H_

--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -454,19 +454,6 @@ bool routeDistances(
   std::vector<double> arc_lengths;
   arc_lengths.resize(max_index-min_index+1);
 
-  // arc_lengths[0] = 0.0;
-  // for (size_t i = 1; i < arc_lengths.size(); i++) {
-  //   const tf::Vector3 pt1 = route.points[min_index+i].position();
-  //   const tf::Vector3 pt2 = route.points[min_index+i-1].position();
-  //   arc_lengths[i] = arc_lengths[i-1] + (pt2-pt1).length();
-  // }
-
-  // size_t roi_start_index = start_index - min_index;
-  // const double start_length = arc_lengths[roi_start_index];
-  // for (size_t i = 1; i < arc_lengths.size(); i++) {
-  //   arc_lengths[i] -= start_length;
-  // }
-
   arc_lengths[roi_start_index] = 0.0;
   if (route.header.frame_id == stu::_wgs84_frame) {
     // Calculate the lengths before the start point.


### PR DESCRIPTION
This commit adds two utility functions to calculate the distances (in
terms of arc length) between route points.  One function calculates
the distance between two points, the other calculates the distance
between one point and many other points and should provide much better
performance for that common need.