### PR TITLE
Add swri_nodelet package (indigo).

### DIFF
--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(swri_nodelet)
+
+set(BUILD_DEPS 
+  nodelet
+  )
+
+set(RUNTIME_DEPS ${BUILD_DEPS})
+
+find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
+catkin_package(
+  CATKIN_DEPENDS ${RUNTIME_DEPS}
+  )
+
+install(PROGRAMS 
+  nodes/nodelet
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/swri_nodelet/README.md
+++ b/swri_nodelet/README.md
@@ -1,0 +1,7 @@
+# swri_nodelet
+
+This package provides a simple script that simplifies writing launch
+files that easily switch between running nodelets as in a shared
+nodelet manager or as standalone processes.  
+
+See the example launch files for details on how to use this package.

--- a/swri_nodelet/launch/example.launch
+++ b/swri_nodelet/launch/example.launch
@@ -1,0 +1,66 @@
+<launch>
+  <!-- This is an example launch file that demonstrates how to use
+       swri_nodelet/nodelet to write simple launch files that can
+       easily switch between running nodelets in a shared manager or
+       as standalone nodes.
+
+       The top level argument "use_nodelet" controls how the nodelets
+       are launched.  A value of true launches the nodelets in a
+       common manager, while a value of false launches the nodelets as
+       standalone processes.
+
+       The "use_nodelet" argument is used to set the value of the
+       "nodelet_manager" argument.  To run as standalone processes,
+       the nodelet_manager is set to "standalone" to tell
+       swri_nodelet/nodelet to run as a unique process.  Otherwise,
+       "nodelet_manager" is set to a node name of the manager that we
+       want to launch.  Note that we have to explicitly include a
+       leading slash in the argument so that nodelets can be launched
+       properly from namespaces.
+
+       Next, the nodelet manager is launched if use_nodelets is true.
+       The manager's name does not include the leading slash because
+       the full node path is derived from the namespace of the node
+       tag.
+
+       Finally, we can use the swri_nodelet to launch nodes.  The node
+       pkg is always swri_nodelet and the type is always nodelet.  The
+       specific nodelet type is provided in the arguments, just as
+       with the stock nodelet launcher.  The only difference is the
+       order of the arguments.
+       
+
+This is almost exactly the same as using the stock nodelet launcher,
+except the arguments are slightly changed.
+       -->
+
+  <!-- Setup for launch nodelets together or standalone -->
+  <arg name="use_nodelets" default="false"/>  
+  <arg name="nodelet_manager" value="standalone" unless="$(arg use_nodelets)"/>
+  <arg name="nodelet_manager" value="/nodelet_manager" if="$(arg use_nodelets)"/>
+  <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager" if="$(arg use_nodelets)">
+    <rosparam name="num_worker_threads" value="8"/>
+  </node>
+
+  <!-- Launching nodes from the same namespace -->
+  <node name="my_root_node"
+        pkg="swri_nodelet" type="nodelet"
+        args="my_package/my_nodelet $(arg nodelet_manager)">
+    <!-- ... -->
+  </node>
+
+  <!-- Launching nodes from the other namespaces -->
+  <group ns="my_namespace">
+    <node name="my_namespaced_node"
+          pkg="swri_nodelet" type="nodelet"
+          args="my_package/my_nodelet $(arg nodelet_manager)">
+      <!-- ... -->
+    </node>
+  </group>
+
+  <!-- The configuration is easily shared with included launch files. -->
+  <include file="$(find swri_nodelet)/launch/example_include.launch">
+    <arg name="nodelet_manager" value="$(arg nodelet_manager)"/>
+  </include>
+
+</launch>

--- a/swri_nodelet/launch/example_include.launch
+++ b/swri_nodelet/launch/example_include.launch
@@ -1,0 +1,17 @@
+<launch>
+  <!-- This approach is easy to extend to included launch files.  The
+       included launch files are given an argument for
+       "nodelet_manager".  Setting the default value to "standalone"
+       makes it possible to run the included launch file directly for
+       testing.  After that, nodelets are launched exactly as in the
+       root launch file. -->
+
+  <arg name="nodelet_manager" default="standalone"/>
+
+  <node name="my_included_node"
+        pkg="swri_nodelet" type="nodelet"
+        args="my_pacakge/my_nodelet $(arg nodelet_manager">
+    <!-- ... -->
+  </node>
+
+</launch>

--- a/swri_nodelet/nodes/nodelet
+++ b/swri_nodelet/nodes/nodelet
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script loads a nodelet using the standard nodelet manager. It
+# uses an alternative syntax to the nodelet command that makes writing
+# programmable launch files simpler.  The command syntax is:
+#
+# nodelet_launcher [nodelet_type] [target] [ROS arguments...]
+# 
+# where target is either the name of a nodelet manager or one of the
+# special keywords:
+# 
+# standalone - Run as a standalone nodelet
+
+# Pop the nodelet type and manager off the argument list.
+NODELET_TYPE=$1
+NODELET_MANAGER=$2
+shift
+shift
+
+if [ $NODELET_MANAGER = "standalone" ]
+then
+    echo Launching nodelet of type $NODELET_TYPE in standalone configuration.
+    rosrun nodelet nodelet standalone $NODELET_TYPE $@
+else
+    echo Launching nodelet of type $NODELET_TYPE on nodelet manager $NODELET_MANAGER
+    rosrun nodelet nodelet load $NODELET_TYPE $NODELET_MANAGER $@
+fi

--- a/swri_nodelet/package.xml
+++ b/swri_nodelet/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>swri_nodelet</name>
+  <version>0.0.1</version>
+  <description>
+    This package provides a simple script to write simple launch files
+    that can easily switch between running nodelets together or as
+    standalone nodes.
+  </description>
+
+  <maintainer email="elliot.johnson@swri.org">Elliot Johnson</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>nodelet</depend>
+</package>


### PR DESCRIPTION
This package simplifies launch files that can easily change between
running nodelets in a shared manager or as standalone processes. 

See the example launch files for an explanation of how to use this package.

@evenator @jatowler 