### PR TITLE
Tweaking the Travis CI to allow build failures for the main repo (Jade)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
   matrix:
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+matrix:
+  allow_failures:
+    - env: ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script: 


### PR DESCRIPTION
After some discussion with @evenator  and @elliotjo, we decided it would be better for builds to pass as long as the build succeeds against the ros-shadow-fixed repository, since it will have the latest bloomed version of marti_messages.