### PR TITLE
Add error message for non-unique route point IDs.

### DIFF
--- a/swri_route_util/src/route.cpp
+++ b/swri_route_util/src/route.cpp
@@ -240,5 +240,9 @@ void Route::rebuildPointIndex() const
   for (size_t i = 0; i < points.size(); ++i) {
     point_index_[points[i].id()] = i;
   }
+
+  if (point_index_.size() != points.size()) {
+    ROS_ERROR("Route points do not have unique IDs.  This will likely cause problems.");
+  }
 }
 }  // namespace swri_route_util


### PR DESCRIPTION
This commit adds an error check when a sru::Route rebuilds it's point
index.  If the point IDs are not unique, the route will output an
error message that should make tracking down problems easier.  This
check is extremely lightweight and should not have a performance
impact.