### PR TITLE
Add a CMake macro to automatically create wrapper nodes

### DIFF
--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -12,19 +12,41 @@ set(RUNTIME_DEPS ${BUILD_DEPS})
 find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
 catkin_package(
   CATKIN_DEPENDS ${RUNTIME_DEPS}
+  INCLUDE_DIRS include
+  CFG_EXTRAS swri_nodelet-extras.cmake
 )
 
-include_directories(${catkin_INCLUDE_DIRS})
+# nodelet.cpp.in must be copied before include(...) or clean builds will fail
+file(COPY nodelet.cpp.in
+   DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+set(swri_nodelet_PREFIX ${CATKIN_DEVEL_PREFIX})  # Allows use of nodelet.cpp.in in swri_nodelet_add_node macro for this build
+include(${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/swri_nodelet-extras.cmake)  # Allows use of swri_nodelet_add_node macro for this build
+
+include_directories(${catkin_INCLUDE_DIRS} include)
 
 add_library(swri_nodelet_test src/test_nodelet.cpp)
 target_link_libraries(swri_nodelet_test ${catkin_LIBRARIES})
+
+swri_nodelet_add_node(test_node swri_nodelet TestNodelet)
+target_link_libraries(test_node swri_nodelet_test)
 
 if(CATKIN_ENABLE_TESTING)
     find_package(rostest REQUIRED)
     add_rostest(test/test_manager.test DEPENDENCIES swri_nodelet_test)
     add_rostest(test/test_standalone.test DEPENDENCIES swri_nodelet_test)
+    add_rostest(test/test_node_wrapper.test DEPENDENCIES test_node)
 endif()
 
 install(PROGRAMS 
   nodes/nodelet
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(FILES nodelet.cpp.in
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)

--- a/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
+++ b/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+set(swri_nodelet_SHARE ${swri_nodelet_PREFIX}/@CATKIN_PACKAGE_SHARE_DESTINATION@)
+
+macro(swri_nodelet_add_node NODELET_NODENAME NODELET_NS NODELET_CLASS)
+  find_package(roscpp REQUIRED)
+  find_package(nodelet REQUIRED)
+  include_directories(${roscpp_INCLUDE} ${nodelet_INCLUDE})
+  set(NODELET_NODENAME ${NODELET_NODENAME})
+  set(NODELET_NS ${NODELET_NS})
+  set(NODELET_CLASS ${NODELET_CLASS})
+  configure_file(${swri_nodelet_SHARE}/nodelet.cpp.in "${NODELET_NODENAME}.cpp")
+  add_executable(${NODELET_NODENAME} "${NODELET_NODENAME}.cpp")
+  target_link_libraries(${NODELET_NODENAME} ${roscpp_LIBRARIES} ${nodelet_LIBRARIES})
+  unset(NODELET_NODENAME)
+  unset(NODELET_NS)
+  unset(NODELET_CLASS)
+endmacro()

--- a/swri_nodelet/include/swri_nodelet/class_list_macros.h
+++ b/swri_nodelet/include/swri_nodelet/class_list_macros.h
@@ -1,0 +1,56 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef SWRI_NODELET_CLASS_LIST_MACROS_H_
+#define SWRI_NODELET_CLASS_LIST_MACROS_H_
+
+#include <pluginlib/class_list_macros.h>
+
+/*
+ Macro to define a nodelet with a factory function, so that it can be used in
+ boilerplate wrapper nodes that do not rely on dynamic class loading.
+ 
+ The macro calls PLUGINLIB_EXPORT_CLASS with plugin type nodelet::Nodelet and
+ creates a factory function NS::createCLASS() that returns a 
+ boost::shared_ptr<nodelet::Nodelet> to NS::CLASS
+ 
+ @param NS The namespace of the class to be used for the nodelet
+ @param CLASS The classname of the class to be used for the nodelet
+*/
+#define SWRI_NODELET_EXPORT_CLASS(NS, CLASS) PLUGINLIB_EXPORT_CLASS(NS::CLASS, nodelet::Nodelet);\
+namespace NS\
+{\
+  boost::shared_ptr<nodelet::Nodelet> create ## CLASS()\
+  {\
+    return boost::make_shared<CLASS>();\
+  }\
+}
+
+#endif  // SWRI_NODELET_CLASS_LIST_MACROS_H_
+

--- a/swri_nodelet/nodelet.cpp.in
+++ b/swri_nodelet/nodelet.cpp.in
@@ -1,0 +1,19 @@
+#include <boost/shared_ptr.hpp>
+#include "ros/ros.h"
+#include "nodelet/nodelet.h"
+
+namespace @NODELET_NS@
+{
+  boost::shared_ptr<nodelet::Nodelet> create@NODELET_CLASS@();
+}  // namespace @NODELET_NS@
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "@NODELET_NODENAME@");
+  nodelet::M_string remap(ros::names::getRemappings());;
+  nodelet::V_string my_argv;
+  boost::shared_ptr<nodelet::Nodelet> n = @NODELET_NS@::create@NODELET_CLASS@();
+  n->init(ros::this_node::getName(), remap, my_argv);
+  ros::spin();
+  return 0;
+}

--- a/swri_nodelet/src/test_nodelet.cpp
+++ b/swri_nodelet/src/test_nodelet.cpp
@@ -54,5 +54,5 @@ namespace swri_nodelet
   };
 }
 
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_EXPORT_CLASS(swri_nodelet::TestNodelet, nodelet::Nodelet);
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_nodelet, TestNodelet);

--- a/swri_nodelet/test/test_node_wrapper.test
+++ b/swri_nodelet/test/test_node_wrapper.test
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="nodelet" pkg="swri_nodelet" type="test_node"/>
+  <test test-name="standalone_test" pkg="swri_nodelet" type="test_nodelet_exists.py" />
+</launch>


### PR DESCRIPTION
Defines a CMake macro `swri_nodelet_add_node(NODELET_NODENAME NODELET_TYPE)` that automatically generates the c++ code for a node wrapper with node name `NODELET_NODENAME` that wraps the nodelet of type `NODELET_TYPE` and makes a CMake target to build the node.