### PR TITLE
Fix projectOntoRoute for points past the end of the route. (jade)

### DIFF
--- a/swri_route_util/include/swri_route_util/util.h
+++ b/swri_route_util/include/swri_route_util/util.h
@@ -86,7 +86,7 @@ bool projectOntoRoute(marti_nav_msgs::RoutePosition &position,
 //     the segment containing the position, and the distance will be
 //     less than that length of that segment.
 //
-//  This function fails the original position's id is not found in the
+//  This function fails if the original position's id is not found in the
 // route.  This function assumes the route is in a cartesian (e.g. not
 // WGS84) frame.
 bool normalizeRoutePosition(marti_nav_msgs::RoutePosition &normalized_position,

--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -225,14 +225,29 @@ bool projectOntoRoute(mnm::RoutePosition &position,
                                  route.points[i+1].position(),
                                  point,
                                  true, false);
-  } else if (extrapolate_past_end && min_segment_index + 2 == route.points.size()) {
-    size_t i = min_segment_index - 1;
+  } else if (min_segment_index + 2 == route.points.size()) {
+    // The end of the route is a special case.  If we go past the end,
+    // we want to return a position with the id of the last point and
+    // the distance past it.  This annoying complicates things in a
+    // number of places, but makes it easy to check if a point is past
+    // the end of a route.    
+    size_t i = min_segment_index;
     nearestDistanceToLineSegment(min_distance_from_line,
                                  min_distance_on_line,
                                  route.points[i+0].position(),
                                  route.points[i+1].position(),
                                  point,
                                  false, true);
+
+    double last_length = (route.points[i+1].position() - route.points[i+0].position()).length();
+    if (min_distance_on_line > last_length) {
+      min_segment_index++;
+      min_distance_on_line -= last_length;
+    }
+
+    if (!extrapolate_past_end) {
+      min_distance_on_line = 0.0;
+    }
   }
 
   position.id = route.points[min_segment_index].id();


### PR DESCRIPTION
This fixes projectOntoRoute to return a normalized route coordinate
when the point is past the end of the route.