### PR TITLE
Add native support for the "stop_point" property in route points.

### DIFF
--- a/swri_route_util/include/swri_route_util/route_point.h
+++ b/swri_route_util/include/swri_route_util/route_point.h
@@ -34,6 +34,8 @@
 
 #include <tf/tf.h>
 
+#include <marti_nav_msgs/RoutePosition.h>
+
 namespace swri_route_util
 {
 // The RoutePoint class provides a more friendly interface for working
@@ -45,6 +47,8 @@ namespace swri_route_util
 class RoutePoint
 {
  public:
+  RoutePoint();
+
   // Access to the route point's position as tf datatypes.
   void setPosition(const tf::Vector3 &position);
   const tf::Vector3& position() const;
@@ -77,6 +81,22 @@ class RoutePoint
   // but are typically not set for interpolated points.
   const std::string& id() const;
   void setId(const std::string &id);
+
+  // Native access to the route point "stop_point" property.  This is
+  // a boolean property that defaults to false if it is not explicitly
+  // defined in the route.
+  bool stopPoint() const;
+  void setStopPoint(bool value);
+
+  // Native access to the route point "stop_point_delay" property.
+  // This is a floating point value that specifies how long the
+  // vehicle should be paused at the specific point, in seconds.  The
+  // delay defaults to 0.0 if it not defined in the route.
+  double stopPointDelay() const;
+  void setStopPointDelay(double delay);
+
+  // Return a marti_nav_msgs::RoutePosition message that corresponds to this point.
+  marti_nav_msgs::RoutePosition routePosition() const;
 
   // The following methods provide general purpose access to route
   // point properties.  They will also correctly map to properties
@@ -115,6 +135,9 @@ class RoutePoint
   tf::Quaternion orientation_;
 
   std::string id_;
+
+  bool stop_point_;
+  double stop_point_delay_;
 
   std::map<std::string, std::string> properties_;
 };  // class RoutePoint

--- a/swri_route_util/include/swri_route_util/route_point_inline.h
+++ b/swri_route_util/include/swri_route_util/route_point_inline.h
@@ -141,6 +141,39 @@ void RoutePoint::setId(const std::string &id)
   id_ = id;
 }
 
+inline
+marti_nav_msgs::RoutePosition RoutePoint::routePosition() const
+{
+  marti_nav_msgs::RoutePosition position;
+  position.id = id();
+  position.distance = 0.0;
+  return position;
+}
+
+inline
+bool RoutePoint::stopPoint() const
+{
+  return stop_point_;
+}
+
+inline
+void RoutePoint::setStopPoint(bool value)
+{
+  stop_point_ = value;
+}
+
+inline
+double RoutePoint::stopPointDelay() const
+{
+  return stop_point_delay_;
+}
+
+inline
+void RoutePoint::setStopPointDelay(double delay)
+{
+  stop_point_delay_ = delay;
+}
+
 template <typename T>
 inline
 T RoutePoint::getTypedProperty(const std::string &name) const

--- a/swri_route_util/src/route_point.cpp
+++ b/swri_route_util/src/route_point.cpp
@@ -30,12 +30,17 @@
 
 namespace swri_route_util
 {
+RoutePoint::RoutePoint()
+{
+  id_ = "<not-initialized>";
+  stop_point_ = false;
+}
+
 std::vector<std::string> RoutePoint::getPropertyNames() const
 {
   std::vector<std::string> names;
-  // Add native properties first.
-  // But we don't have any yet.
-  // names.push_back("name");
+  names.push_back("stop_point");
+  names.push_back("stop_point_delay");
 
   for (auto const &it : properties_) {
     names.push_back(it.first);
@@ -46,11 +51,14 @@ std::vector<std::string> RoutePoint::getPropertyNames() const
 
 std::string RoutePoint::getProperty(const std::string &name) const
 {
-  // Check for native properties first.
-  // But we don't have any yet.
-  // if (name == "name") {
-  //   return name_;
-  // } else
+  if (name == "stop_point") {
+    return stop_point_ ? "true" : "false";
+  }
+
+  if (name == "stop_point_delay") {
+    return boost::lexical_cast<std::string>(stop_point_delay_);
+  }
+
   if (properties_.count(name)) {
     return properties_.at(name);
   } else {
@@ -60,23 +68,20 @@ std::string RoutePoint::getProperty(const std::string &name) const
 
 bool RoutePoint::hasProperty(const std::string &name) const
 {
-  // Check for native properties first.
-  // But we don't have any yet.
-  // if (name == "name") {
-  //   return true;
-  // } else
+  if (name == "stop_point") { return true; }
+  if (name == "stop_point_delay") { return true; }
   return properties_.count(name);
 }
 
 void RoutePoint::setProperty(const std::string &name, const std::string &value)
 {
-  // Check for native properties first.
-  // But we don't have any yet.
-  // if (name == "name") {
-  //   name_ = value;
-  // } else {
+  if (name == "stop_point") {
+    stop_point_ = (value == "1");
+  } else if (name == "stop_point_delay") {
+    stop_point_delay_ = boost::lexical_cast<double>(value);
+  } else {
     properties_[name] = value;
-  // }   
+  }
 }
 
 void RoutePoint::deleteProperty(const std::string &name)


### PR DESCRIPTION
This commit adds native support for the "stop_point" property for
swri_route_util::RoutePoint.  This property defaults to false when it
is not explicitly set to true in the route point.