### PR TITLE
Add Tests to swri_nodelet

### DIFF
--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -17,6 +17,12 @@ catkin_package(
 add_library(swri_nodelet_test src/test_nodelet.cpp)
 target_link_libraries(swri_nodelet_test ${catkin_LIBRARIES})
 
+if(CATKIN_ENABLE_TESTING)
+    find_package(rostest REQUIRED)
+    add_rostest(test/test_manager.test DEPENDENCIES swri_nodelet_test)
+    add_rostest(test/test_standalone.test DEPENDENCIES swri_nodelet_test)
+endif()
+
 install(PROGRAMS 
   nodes/nodelet
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -3,14 +3,19 @@ project(swri_nodelet)
 
 set(BUILD_DEPS 
   nodelet
-  )
+  roscpp
+  std_msgs
+)
 
 set(RUNTIME_DEPS ${BUILD_DEPS})
 
 find_package(catkin REQUIRED COMPONENTS ${BUILD_DEPS})
 catkin_package(
   CATKIN_DEPENDS ${RUNTIME_DEPS}
-  )
+)
+
+add_library(swri_nodelet_test src/test_nodelet.cpp)
+target_link_libraries(swri_nodelet_test ${catkin_LIBRARIES})
 
 install(PROGRAMS 
   nodes/nodelet

--- a/swri_nodelet/nodelet_plugins.xml
+++ b/swri_nodelet/nodelet_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libswri_nodelet_test">
+  <class name="swri_nodelet/TestNodelet" type="swri_nodelet::TestNodelet" base_class_type="nodelet::Nodelet">
+  <description>
+  A simple nodelet for testing swri_nodelet functionality.
+  </description>
+  </class>
+</library>

--- a/swri_nodelet/package.xml
+++ b/swri_nodelet/package.xml
@@ -14,4 +14,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>nodelet</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
 </package>

--- a/swri_nodelet/src/test_nodelet.cpp
+++ b/swri_nodelet/src/test_nodelet.cpp
@@ -1,0 +1,58 @@
+// *****************************************************************************
+//
+// Copyright (c) 2016, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+#include <std_msgs/Int32.h>
+
+namespace swri_nodelet
+{
+  class TestNodelet : public nodelet::Nodelet
+  {
+    public:
+      virtual void onInit()
+      {
+        publisher_ = getNodeHandle().advertise<std_msgs::Int32>("numbers", 2);
+        timer_ = getNodeHandle().createTimer(ros::Duration(0.1), &TestNodelet::timerCallback, this);
+      }
+    private:
+      ros::Publisher publisher_;
+      ros::Timer timer_;
+      
+      void timerCallback(ros::TimerEvent const& e)
+      {
+        std_msgs::Int32 msg;
+        msg.data = 1337;
+        publisher_.publish(msg);
+      }
+  };
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(swri_nodelet::TestNodelet, nodelet::Nodelet);

--- a/swri_nodelet/test/test_manager.test
+++ b/swri_nodelet/test/test_manager.test
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<launch>
+  <node pkg="nodelet" type="nodelet" name="nodelet_manager" args="manager"/>
+  <node name="nodelet" pkg="swri_nodelet" type="nodelet" args="swri_nodelet/TestNodelet nodelet_manager"/>
+  <test test-name="standalone_test" pkg="swri_nodelet" type="test_nodelet_exists.py" />
+</launch>

--- a/swri_nodelet/test/test_nodelet_exists.py
+++ b/swri_nodelet/test/test_nodelet_exists.py
@@ -1,0 +1,32 @@
+#! /usr/bin/env python
+
+import rospy
+import rostest
+from std_msgs.msg import Int32
+import sys
+from time import sleep
+import unittest
+
+PKG = 'swri_nodelet'
+NAME = 'test_nodelet_exists'
+
+class TestNodeletExists(unittest.TestCase):
+    
+    def callback(self, msg):
+        self.msg = msg
+    
+    def test_init(self):
+        ''' 
+        Test that the test nodelet exists by waiting for the message it
+        publishes.
+        '''
+        self.msg = None
+        sub = rospy.Subscriber('numbers', Int32, self.callback)
+        while self.msg is None:
+            sleep(0.1)
+        sub.unregister()
+        self.assertEquals(self.msg.data, 1337)
+        
+if __name__ == '__main__':
+    rospy.init_node(NAME)
+    rostest.rosrun(PKG, NAME, TestNodeletExists, sys.argv)

--- a/swri_nodelet/test/test_standalone.test
+++ b/swri_nodelet/test/test_standalone.test
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="nodelet" pkg="swri_nodelet" type="nodelet" args="swri_nodelet/TestNodelet standalone"/>
+  <test test-name="standalone_test" pkg="swri_nodelet" type="test_nodelet_exists.py" />
+</launch>


### PR DESCRIPTION
Adds two tests to swri_nodelet. One for running standalone, and one for running from a manager.