### PR TITLE
Fix OpenCV dependencies for Kinetic build

### DIFF
--- a/swri_console_util/package.xml
+++ b/swri_console_util/package.xml
@@ -13,7 +13,6 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
-  <depend>libopencv-dev</depend>
   <depend>roscpp</depend>
   <depend>swri_math_util</depend>
 

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 add_definitions(${EIGEN3_DEFINITIONS})
 
-find_package(OpenCV 2 REQUIRED)
+find_package(OpenCV 3.1 COMPONENTS core REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/swri_geometry_util/package.xml
+++ b/swri_geometry_util/package.xml
@@ -13,9 +13,9 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
+  <depend>cv_bridge</depend>
   <depend>eigen</depend>
   <depend>libgeos++-dev</depend>
-  <depend>libopencv-dev</depend>
   <depend>roscpp</depend>
   <depend>tf</depend>
 </package>

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-find_package(OpenCV 3.1 )
+find_package(OpenCV 3.1 REQUIRED)
 
 find_package(Qt5Gui REQUIRED)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/swri_opencv_util/package.xml
+++ b/swri_opencv_util/package.xml
@@ -13,7 +13,7 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
-  <depend>libopencv-dev</depend>
+  <depend>cv_bridge</depend>
   <depend>swri_math_util</depend>
 
 </package>


### PR DESCRIPTION
This fixes some dependencies in various package.xml and CMakeLists.txt files to ensure that OpenCV 3.1 is used everywhere.

Fixes #399 