### PR TITLE
Include boost/make_shared.hpp

### DIFF
--- a/swri_nodelet/include/swri_nodelet/class_list_macros.h
+++ b/swri_nodelet/include/swri_nodelet/class_list_macros.h
@@ -30,6 +30,7 @@
 #ifndef SWRI_NODELET_CLASS_LIST_MACROS_H_
 #define SWRI_NODELET_CLASS_LIST_MACROS_H_
 
+#include <boost/make_shared.hpp>
 #include <pluginlib/class_list_macros.h>
 
 /*


### PR DESCRIPTION
This header is necessary in the unlikely event that the using cpp file hasn't included boost/make_shared.hpp anywhere else. Also, it's good practice to include what you use.