### PR TITLE
Make swri_yaml_util build out-of-source

### DIFF
--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -8,8 +8,10 @@ pkg_check_modules(YamlCpp yaml-cpp)
 message(STATUS "YAML-CPP VERSION: " ${YamlCpp_VERSION})
 message(STATUS "YAML-CPP LIBRARY: " ${YamlCpp_LIBRARIES})
 
+catkin_destinations()
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
   LIBRARIES ${PROJECT_NAME} ${YamlCpp_LIBRARIES}
 )
 
@@ -21,7 +23,7 @@ else()
   message(STATUS "  Using new yaml-cpp API.")
 endif()
 
-configure_file(version.h.in ${PROJECT_SOURCE_DIR}/include/${PROJECT_NAME}/version.h)
+configure_file(version.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/version.h)
 
 find_package(Boost REQUIRED)
 
@@ -35,6 +37,11 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${YamlCpp_LIBRARIES})
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
+)
+
+install(
+  DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -27,7 +27,12 @@ configure_file(version.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DEST
 
 find_package(Boost REQUIRED)
 
-include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${YamlCpp_INCLUDE_DIR})
+include_directories(include
+  ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+  ${YamlCpp_INCLUDE_DIR}
+)
 
 add_library(${PROJECT_NAME}
   src/yaml_util.cpp


### PR DESCRIPTION
Fixes #411 by generating version.h in the devel space include folder instead of the source space.
Based heavily on http://answers.ros.org/question/123221/