### PR TITLE
Remove unused gps_common dependency

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
   diagnostic_msgs
   dynamic_reconfigure
   geometry_msgs
-  gps_common
   nodelet
   pluginlib
   roscpp


### PR DESCRIPTION
Fix #421 by removing gps_common from the swri_transform_util CMakeLists.txt in kinetic.