### PR TITLE
Increase queue_size in swri_roscpp/Subscriber. (indigo)

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -360,7 +360,7 @@ class StorageSubscriberImpl : public SubscriberImpl
 
     dest_ = dest;
 
-    sub_ = nh.subscribe(mapped_topic_, 1,
+    sub_ = nh.subscribe(mapped_topic_, 2,
                         &StorageSubscriberImpl::handleMessage<M>,
                         this,
                         transport_hints);


### PR DESCRIPTION
This commit increases the queue size for subscribers that use the
store mechanism instead of a callback.  The queue size was set to 1,
which we have seen problems with, so this will increase it to 2.