### PR TITLE
Ignore invalid fixes (Indigo)

### DIFF
--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -42,6 +42,10 @@ def parse_origin(local_xy_origin):
     return
 
 def gps_callback(data):
+    if data.status.status == -1:
+        # This fix is invalid, ignore it and wait until we get a valid one
+        rospy.logwarn("Got invalid fix.  Waiting for a valid one...")
+        return
     global _gps_fix
     
     if _gps_fix == None:


### PR DESCRIPTION
Note that the Indigo branch is slightly different since it uses the `GPSFix` branch rather than `NavSatFix`.  I haven't tested this on an Indigo system yet.

Fixes #431 
