### PR TITLE
Blend with transparency jade

### DIFF
--- a/swri_image_util/include/swri_image_util/blend_images_util.h
+++ b/swri_image_util/include/swri_image_util/blend_images_util.h
@@ -44,6 +44,19 @@ namespace swri_image_util
       const cv::Mat& top_image,
       const double alpha,
       cv::Mat& dest_image);
+
+  /**
+   * Blends two images together. top_image will be drawn on top of base_image
+   * with a blending level of alpha. The color mask_color will be made
+   * transparent in the top_image. The blended image will be placed in
+   * dest_image
+   */
+  void blendImages(
+      const cv::Mat& base_image,
+      const cv::Mat& top_image,
+      const double alpha,
+      const cv::Scalar mask_color,
+      cv::Mat& dest_image);
 }
 
 #endif // IMAGE_UTIL_BLEND_IMAGES_H_

--- a/swri_image_util/src/blend_images_util.cpp
+++ b/swri_image_util/src/blend_images_util.cpp
@@ -77,8 +77,6 @@ namespace swri_image_util
       const cv::Scalar mask_color,
       cv::Mat& dest_image)
   {
-    const bool debug = false;
-
     // All images must have the same shape. Return without modifying anything
     // if this is not the case
     if ((base_image.rows != top_image.rows)
@@ -134,26 +132,5 @@ namespace swri_image_util
 
     // 5. Add the masked blend and the masked base together
     cv::add(masked_base, masked_top, dest_image);
-
-    if (debug == true)
-    {
-      cv::namedWindow("Mask", cv::WINDOW_AUTOSIZE);
-      cv::imshow("Mask", mask);
-      cv::waitKey(0);
-
-      cv::namedWindow("Masked Image", cv::WINDOW_AUTOSIZE);
-      cv::imshow("Masked Image", masked_top);
-      cv::waitKey(0);
-
-      cv::namedWindow("Masked Base", cv::WINDOW_AUTOSIZE);
-      cv::imshow("Masked Base", masked_base);
-      cv::waitKey(0);
-
-      cv::namedWindow("Final", cv::WINDOW_AUTOSIZE);
-      cv::imshow("Final", dest_image);
-      cv::waitKey(0);
-
-      cv::destroyAllWindows();
-    }
   }
 }

--- a/swri_image_util/src/blend_images_util.cpp
+++ b/swri_image_util/src/blend_images_util.cpp
@@ -30,8 +30,6 @@
 #include <ros/ros.h>
 #include <swri_image_util/blend_images_util.h>
 
-#include <opencv2/highgui/highgui.hpp>
-
 namespace swri_image_util
 {
   void blendImages(


### PR DESCRIPTION
Instead of blending an entire image, mask out portions that are a
particular color (e.g., for a black-and-white top image, only blend the
white portions, so the black portions don't darken the entire base image).

Adds three parameters to the swri_image_util blend_images_nodelet (mask
red, green, and blue components).

Fixes #440