### PR TITLE
Create warp_image Nodelet

### DIFF
--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   swri_geometry_util
   swri_math_util
+  swri_nodelet
   swri_opencv_util
   tf
 )
@@ -91,14 +92,27 @@ add_library(${PROJECT_NAME}_nodelets
   src/nodelets/normalize_response_nodelet.cpp
   src/nodelets/rotate_image_nodelet.cpp
   src/nodelets/scale_image_nodelet.cpp
+  src/nodelets/warp_image_nodelet.cpp
 )
 target_link_libraries(${PROJECT_NAME}_nodelets ${PROJECT_NAME})
+
+add_executable(blend_images src/nodes/blend_images_node.cpp)
+target_link_libraries(blend_images ${catkin_LIBRARIES})
+
+add_executable(contrast_stretch src/nodes/contrast_stretch.cpp)
+target_link_libraries(contrast_stretch ${catkin_LIBRARIES})
+
+add_executable(draw_text src/nodes/draw_text.cpp)
+target_link_libraries(draw_text ${catkin_LIBRARIES})
+
+add_executable(dummy_image_publisher src/nodes/dummy_image_publisher.cpp)
+target_link_libraries(dummy_image_publisher ${catkin_LIBRARIES})
 
 add_executable(normalization_image_generator_node src/nodes/normalization_image_generator_node.cpp)
 target_link_libraries(normalization_image_generator_node ${PROJECT_NAME})
 
-add_executable(dummy_image_publisher src/nodes/dummy_image_publisher.cpp)
-target_link_libraries(dummy_image_publisher ${catkin_LIBRARIES})
+add_executable(normalize_response src/nodes/normalize_response.cpp)
+target_link_libraries(normalize_response ${catkin_LIBRARIES})
 
 add_executable(rotate_image src/nodes/rotate_image.cpp)
 target_link_libraries(rotate_image ${catkin_LIBRARIES})
@@ -106,17 +120,8 @@ target_link_libraries(rotate_image ${catkin_LIBRARIES})
 add_executable(scale_image src/nodes/scale_image.cpp)
 target_link_libraries(scale_image ${catkin_LIBRARIES})
 
-add_executable(draw_text src/nodes/draw_text.cpp)
-target_link_libraries(draw_text ${catkin_LIBRARIES})
-
-add_executable(contrast_stretch src/nodes/contrast_stretch.cpp)
-target_link_libraries(contrast_stretch ${catkin_LIBRARIES})
-
-add_executable(normalize_response src/nodes/normalize_response.cpp)
-target_link_libraries(normalize_response ${catkin_LIBRARIES})
-
-add_executable(blend_images src/nodes/blend_images_node.cpp)
-target_link_libraries(blend_images ${catkin_LIBRARIES})
+swri_nodelet_add_node(warp_image ${PROJECT_NAME} WarpImageNodelet)
+target_link_libraries(warp_image ${PROJECT_NAME}_nodelets ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
@@ -131,14 +136,15 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 install(TARGETS ${PROJECT_NAME} 
     ${PROJECT_NAME}_nodelets
-    normalization_image_generator_node 
+    blend_images
+    contrast_stretch
+    draw_text
     dummy_image_publisher
+    normalization_image_generator_node
+    normalize_response
     rotate_image
     scale_image
-    draw_text
-    contrast_stretch
-    normalize_response
-    blend_images
+    warp_image
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/swri_image_util/nodelet_plugins.xml
+++ b/swri_image_util/nodelet_plugins.xml
@@ -1,39 +1,37 @@
 <library path="lib/libswri_image_util_nodelets">
-  
-  <class name="swri_image_util/rotate_image" type="swri_image_util::RotateImageNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to rotate an image a multiple of 90 degrees.
-    </description>
-  </class>
-  
-  <class name="swri_image_util/scale_image" type="swri_image_util::ScaleImageNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to scale an image.
-    </description>
-  </class>
-  
-  <class name="swri_image_util/contrast_stretch" type="swri_image_util::ContrastStretchNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to contrast stretch an image.
-    </description>
-  </class>
-
-  <class name="swri_image_util/normalize_response" type="swri_image_util::NormalizeResponseNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to normalize the response of an image.
-    </description>
-  </class>
-
-  <class name="swri_image_util/draw_text" type="swri_image_util::DrawTextNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to draw text on an image.
-    </description>
-  </class>
-
-  <class name="swri_image_util/blend_images" type="swri_image_util::BlendImagesNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet that blends one image onto the top of another.
-    </description>
-  </class>
-  
+    <class name="swri_image_util/blend_images" type="swri_image_util::BlendImagesNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet that blends one image onto the top of another.
+        </description>
+    </class>
+    <class name="swri_image_util/contrast_stretch" type="swri_image_util::ContrastStretchNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to contrast stretch an image.
+        </description>
+    </class>
+    <class name="swri_image_util/draw_text" type="swri_image_util::DrawTextNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to draw text on an image.
+        </description>
+    </class>
+    <class name="swri_image_util/normalize_response" type="swri_image_util::NormalizeResponseNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to normalize the response of an image.
+        </description>
+    </class>
+    <class name="swri_image_util/rotate_image" type="swri_image_util::RotateImageNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to rotate an image a multiple of 90 degrees.
+        </description>
+    </class>
+    <class name="swri_image_util/scale_image" type="swri_image_util::ScaleImageNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to scale an image.
+        </description>
+    </class>
+    <class name="swri_image_util/warp_image" type="swri_image_util::WarpImageNodelet"
+        base_class_type="nodelet::Nodelet">
+        <description> Nodelet to apply a 3x3 transformation to an image.
+        </description>
+    </class>
 </library>

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -28,6 +28,7 @@
   <depend>std_msgs</depend>
   <depend>swri_geometry_util</depend>
   <depend>swri_math_util</depend>
+  <build_depend>swri_nodelet</build_depend>
   <depend>swri_opencv_util</depend>
   <depend>tf</depend>
 

--- a/swri_image_util/src/nodelets/warp_image_nodelet.cpp
+++ b/swri_image_util/src/nodelets/warp_image_nodelet.cpp
@@ -1,0 +1,97 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <cv_bridge/cv_bridge.h>
+#include <image_transport/image_transport.h>
+#include <image_transport/publisher.h>
+#include <image_transport/subscriber.h>
+#include <opencv2/core/core.hpp>
+#include <nodelet/nodelet.h>
+#include <ros/ros.h>
+#include <sensor_msgs/Image.h>
+
+namespace swri_image_util
+{
+  class WarpImageNodelet : public nodelet::Nodelet
+  {
+    public:
+      WarpImageNodelet()
+      {
+
+      }
+
+      ~WarpImageNodelet()
+      {
+
+      }
+
+      void onInit()
+      {
+        ros::NodeHandle &node = getNodeHandle();
+        ros::NodeHandle &priv = getPrivateNodeHandle();
+
+        std::vector<double> transform;
+        priv.param("transform", transform, transform);
+        if (transform.size() != 9)
+        {
+          ROS_FATAL("~transform must be a 9-element list of doubles (3x3 matrix, row major)");
+          // Return without setting up callbacks
+          // Don't shut down, because that would bring down all other nodelets as well
+          return;
+        }
+        m_ = cv::Mat(transform, true);
+        m_ = m_.reshape(3, 3);
+
+        image_transport::ImageTransport it(node);
+        image_pub_ = it.advertise("warped_image", 1);
+        image_sub_ = it.subscribe("image", 1, &WarpImageNodelet::handleImage, this);
+      }
+
+      void handleImage(sensor_msgs::ImageConstPtr const& image)
+      {
+        cv_bridge::CvImageConstPtr cv_image = cv_bridge::toCvShare(image);
+
+        cv_bridge::CvImagePtr cv_warped = boost::make_shared<cv_bridge::CvImage>();
+        cv::warpPerspective(cv_image->image, cv_warped->image, m_, cv_image->image.size(), CV_INTER_LANCZOS4);
+
+        cv_warped->encoding = cv_image->encoding;
+        cv_warped->header = cv_image->header;
+
+        image_pub_.publish(cv_warped->toImageMsg());
+      }
+
+    private:
+      image_transport::Subscriber image_sub_;
+      image_transport::Publisher image_pub_;
+      cv::Mat m_;
+  };
+}
+
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, WarpImageNodelet);

--- a/swri_image_util/src/nodelets/warp_image_nodelet.cpp
+++ b/swri_image_util/src/nodelets/warp_image_nodelet.cpp
@@ -42,14 +42,12 @@ namespace swri_image_util
   class WarpImageNodelet : public nodelet::Nodelet
   {
     public:
-      WarpImageNodelet()
+      WarpImageNodelet(): use_input_size_(false)
       {
-
       }
 
       ~WarpImageNodelet()
       {
-
       }
 
       void onInit()
@@ -77,8 +75,7 @@ namespace swri_image_util
           // Don't shut down, because that would bring down all other nodelets as well
           return;
         }
-        m_ = cv::Mat(transform, true);
-        m_ = m_.reshape(3, 3);
+        m_ = cv::Mat(transform, true).reshape(0, 3);
         NODELET_INFO_STREAM("Transformation matrix:" << std::endl << m_);
 
         image_transport::ImageTransport it(node);


### PR DESCRIPTION
Add a nodelet to swri_image util that applies a 3x3 transformation
matrix to an image using cv::warpPerspective and publishes the
resulting image.

closes #445 