### PR TITLE
Fix dynamic reconfigure in dynamic_publisher (closes issue #448). (jade)

### DIFF
--- a/swri_transform_util/src/nodelets/dynamic_publisher.cpp
+++ b/swri_transform_util/src/nodelets/dynamic_publisher.cpp
@@ -85,8 +85,12 @@ class DynamicPublisher : public nodelet::Nodelet
 
   void ConfigCallback(DynamicPublisherConfig &config, uint32_t level)
   {
-    if (~level)
+    if (~level == 0)
     {
+      // When the dynamic reconfigure server is started, it tries to
+      // set default values by calling this function with all bits of
+      // level set.  We reject these defaults in favor of our
+      // currently stored values.
       config = config_;
     }
     else


### PR DESCRIPTION
The condition for determining if we should read the dynamic parameters
or set them was reversed.  Fixed condition and added a comment to
clarify the check.