### PR TITLE
Document swri tranform util

### DIFF
--- a/swri_transform_util/include/swri_transform_util/earth_constants.h
+++ b/swri_transform_util/include/swri_transform_util/earth_constants.h
@@ -37,6 +37,9 @@ namespace swri_transform_util
    */
   static const double _earth_equator_radius = 6378137.0;
 
+  /**
+   * Earth mean radius
+   */
   static const double _earth_mean_radius = 6371009.0;
 
   /**

--- a/swri_transform_util/include/swri_transform_util/frames.h
+++ b/swri_transform_util/include/swri_transform_util/frames.h
@@ -54,6 +54,9 @@ namespace swri_transform_util
    */
   static const std::string _local_xy_frame = "/local_xy";
 
+  /**
+   * Special frame id used internally to denote frames that are part of the ROS TF tree
+   */
   static const std::string _tf_frame = "/tf";
 }
 

--- a/swri_transform_util/include/swri_transform_util/local_xy_util.h
+++ b/swri_transform_util/include/swri_transform_util/local_xy_util.h
@@ -80,14 +80,25 @@ namespace swri_transform_util
       double& longitude);
 
   /**
-   * Utility class for converting between WGS84 lat/lon and an ortho-rectified
+   * @brief Utility class for converting between WGS84 lat/lon and an ortho-rectified
    * LocalXY coordinate system.
+   *
+   * To use this class, first construct it with a reference origin. The
+   * reference origin should be a latitude, longitude, angle, and altitude in
+   * WGS84 coordinates. Once initialized, a LocalXyWgs84Util can be used to
+   * convert WGS84 coordinates to and from an ortho-rectified frame with its
+   * origin at the reference origin. Because the earth is spherical, the error
+   * in the ortho-rectified frame will accumulate as the distance from the
+   * reference origin increases. For this reason, the reference origin should
+   * be chosen to be close to the region of interest (<10 km).
    */
   class LocalXyWgs84Util
   {
   public:
     /**
-     * Constructor.
+     * @brief Initializing constructor
+     *
+     * This constructor creates and initializes a LocalXyWgs84Util.
      *
      * @param[in] reference_latitude   Reference latitude in degrees.
      * @param[in] reference_longitude  Reference longitude in degrees.
@@ -100,25 +111,60 @@ namespace swri_transform_util
         double reference_angle = 0,
         double reference_altitude = 0);
 
+    /**
+     * @brief Zero-argument constructor.
+     *
+     * This constructor creates an uninitialized LocalXyWgs84Util. This
+     * constructor is only used to create placeholder objects in containers
+     * that require a zero-argument constructor.
+     */
     LocalXyWgs84Util();
 
+    /**
+     * @brief Return whether the object has been initialized
+     *
+     * The object is not usable unless it has been initialized (see the two
+     * constructors).
+     *
+     * @return True if initialized, false otherwise.
+     */
     bool Initialized() const { return initialized_; }
 
+    /**
+     * @brief Return the longitude coordinate of the local origin
+     *
+     * @return The WGS84 longitude coordinate of the local origin in degrees
+     */
     double ReferenceLongitude() const;
 
+    /**
+     * @brief Return the latitude coordinate of the local origin
+     *
+     * @return The WGS84 latitude coordinate of the local origin in degrees
+     */
     double ReferenceLatitude() const;
 
     /**
-     * Returns the reference angle in degrees ENU.
+     * @brief Return the reference angle in degrees ENU.
      */
     double ReferenceAngle() const;
 
+    /**
+     * @brief Return the altitude coordinate of the local origin
+     *
+     * @return The WGS84 altitude coordinate of the local origin in meters
+     */
     double ReferenceAltitude() const;
 
+    /**
+     * @brief Return the TF frame ID corresponding to the local origin
+     *
+     * @return The TF frame ID corresponding to the local origin
+     */
     std::string Frame() const { return frame_; }
 
     /**
-     * Convert WGS84 latitude and longitude to LocalXY.
+     * @brief Convert WGS84 latitude and longitude to LocalXY.
      *
      * @param[in]  latitude   Latitude value in degrees.
      * @param[in]  longitude  Longitude value in degrees.
@@ -134,7 +180,7 @@ namespace swri_transform_util
         double& y) const;
 
     /**
-     * Convert LocalXY to WGS84 latitude and longitude.
+     * @brief Convert LocalXY to WGS84 latitude and longitude.
      *
      * @param[in]  x          X coordinate in meters from origin.
      * @param[in]  y          Y coordinate in meters from origin.

--- a/swri_transform_util/include/swri_transform_util/transform.h
+++ b/swri_transform_util/include/swri_transform_util/transform.h
@@ -38,19 +38,38 @@
 
 namespace swri_transform_util
 {
+  /**
+   * @brief Base class for Transform implementations.
+   *
+   * swri_transform_util::Transform uses a "pointer to implementation" design
+   * pattern. Extend this class to create new implementations of Transform.
+   * TransformImpl and its descendants should not be used bare, only as part
+   * of a swri_transform_util::Transform.
+   */
   class TransformImpl
   {
   public:
     TransformImpl() {}
     virtual ~TransformImpl() {}
+
+    /**
+     * @brief Apply this transform to a 3D vector
+     *
+     * @param[in]  v_in  Input vector
+     * @param[out] v_out Transformed vector
+     */
     virtual void Transform(
       const tf::Vector3& v_in, tf::Vector3& v_out) const = 0;
     
+    /**
+     * @brief Get the orientation of this transform
+     *
+     * Get the orientation of this transform by getting the vector between
+     * the origin point and a point offset 1 on the x axis.
+     * @return The orientation component of the transform
+     */
     virtual tf::Quaternion GetOrientation() const
     {
-      // Get the orientation of this transform by getting the vector between
-      // the origin point and a point offset 1 on the x axis.
-
       tf::Vector3 offset;
       Transform(tf::Vector3(1, 0, 0), offset);
 
@@ -68,12 +87,13 @@ namespace swri_transform_util
       return tf::Quaternion(cross.x(), cross.y(), cross.z(), w).normalized();
     }
     
+    /// Time stamp for this transform
     ros::Time stamp_;
   };
 
   /**
-   * An abstraction of the tf::Transform class to support transforms in addition
-   * to the rigid transforms supported by tf.
+   * @brief An abstraction of the tf::Transform class to support transforms in
+   * addition to the rigid transforms supported by tf.
    *
    * Additional transforms are implemented through transformer plug-ins.
    *
@@ -83,41 +103,33 @@ namespace swri_transform_util
   {
   public:
     /**
-     * Constructor.
-     *
-     * Generates an identity transform.
+     * @brief Generates an identity transform.
      */
     Transform();
 
     /**
-     * Constructor.
-     *
-     * Generates a standard rigid transform from a tf::Transform.
+     * @brief Generates a standard rigid transform from a tf::Transform.
      *
      * @param[in]  transform  The input transform.
      */
     explicit Transform(const tf::Transform& transform);
     
     /**
-     * Constructor.
-     *
-     * Generates a standard rigid transform from a tf::Transform.
+     * @brief Generates a standard rigid transform from a tf::Transform.
      *
      * @param[in]  transform  The input transform.
      */
     explicit Transform(const tf::StampedTransform& transform);
 
     /**
-     * Constructor.
-     *
-     * Defines the transform using an arbitrary transform implementation.
+     * @brief Defines the transform using an arbitrary transform implementation.
      *
      * @param[in]  transform  The input transform implementation.
      */
     explicit Transform(boost::shared_ptr<TransformImpl> transform);
 
     /**
-     * Assignment operator for tf::Transform.
+     * @brief Assignment operator for tf::Transform.
      *
      * Generates a standard rigid transform from a tf::Transform.
      *
@@ -126,7 +138,7 @@ namespace swri_transform_util
     Transform& operator=(const tf::Transform transform);
 
     /**
-     * Assignment operator for TransformImpl.
+     * @brief Assignment operator for TransformImpl.
      *
      * Note: The transform implementation is only a shallow copy.
      *
@@ -135,7 +147,7 @@ namespace swri_transform_util
     Transform& operator=(boost::shared_ptr<TransformImpl> transform);
 
     /**
-     * Return the transform of the vector.
+     * @brief Apply the transform to a vector and return the result.
      *
      * @param[in]  v  The vector.
      *
@@ -144,7 +156,7 @@ namespace swri_transform_util
     tf::Vector3 operator()(const tf::Vector3& v) const;
 
     /**
-     * Return the transform of the vector.
+     * @brief Apply the transform to a vector and return the result.
      *
      * @param[in]  v  The vector.
      *
@@ -153,7 +165,7 @@ namespace swri_transform_util
     tf::Vector3 operator*(const tf::Vector3& v) const;
 
     /**
-     * Return the transform of the quaternion.
+     * @brief Apply the transform to a quaternion and return the result.
      *
      * @param[in]  q  The quaternion.
      *
@@ -162,7 +174,8 @@ namespace swri_transform_util
     tf::Quaternion operator*(const tf::Quaternion& q) const;
 
     /**
-     * Return a TF transform equivalent to this transform
+     * @brief Return a TF transform equivalent to this transform
+     *
      * @return The equivalent tf::Transform
      */
     tf::Transform GetTF() const;
@@ -174,30 +187,86 @@ namespace swri_transform_util
      */
     Transform Inverse() const;
 
+    /**
+     * @brief Get the origin (translation component) of the transform
+     *
+     * The result of this should always be equal to applying the transform to
+     * the vector (0, 0, 0).
+     *
+     * @return The origin (translation component) of the transform
+     */
     tf::Vector3 GetOrigin() const;
 
+    /**
+     * @brief Get the orientation (rotation component) of the transform
+     *
+     * @return The orientation (translation component) of the transform
+     */
     tf::Quaternion GetOrientation() const;
     
+    /**
+     * @brief Get the time stamp of the transform
+     * @return The time stamp of the transform
+     */
     ros::Time GetStamp() { return transform_->stamp_; }
 
   private:
+    /// Pointer to the implementation of the transform
     boost::shared_ptr<TransformImpl> transform_;
   };
 
+  /**
+   * @brief Specialization of swri_transform_util::TransformImpl that represents
+   * the identity transform
+   */
   class IdentityTransform : public TransformImpl
   {
   public:
+    /**
+     * @brief Construct an identity transform with stamp_=ros::Time::now()
+     */
     IdentityTransform() { stamp_ = ros::Time::now(); }
+
+    /**
+     * @brief Apply the identity tranform to a 3D vector(sets v_out=v_in)
+     *
+     * @param[in] v_in  Input vector
+     * @param[out] v_out Ouput vector
+     */
     virtual void Transform(const tf::Vector3& v_in, tf::Vector3& v_out) const;
   };
 
+  /**
+   * @brief Specialization of swri_transform_util::TransformImpl that performs
+   * TF transformation
+   */
   class TfTransform : public TransformImpl
   {
   public:
+    /**
+     * @brief Construct a TfTransform from a tf::Transform
+     * @param transform The TF Transform that this TfTransform performs
+     */
     explicit TfTransform(const tf::Transform& transform);
+
+    /**
+     * @brief Construct a TfTransform from a tf::StampedTransform
+     * @param transform The TF StampedTransform that this TfTransform performs
+     */
     explicit TfTransform(const tf::StampedTransform& transform);
+
+    /**
+     * @brief Apply this transform to a 3D vector using TF
+     *
+     * @param[in]  v_in  Input vector
+     * @param[out] v_out Transformed vector
+     */
     virtual void Transform(const tf::Vector3& v_in, tf::Vector3& v_out) const;
 
+    /**
+     * @brief Get the orientation component of this transform using TF
+     * @return The orientation component of the transform
+     */
     virtual tf::Quaternion GetOrientation() const;
 
   protected:

--- a/swri_transform_util/include/swri_transform_util/transform_manager.h
+++ b/swri_transform_util/include/swri_transform_util/transform_manager.h
@@ -49,36 +49,129 @@ namespace swri_transform_util
   typedef std::map<std::string, boost::shared_ptr<Transformer> > TransformerMap;
   typedef std::map<std::string, TransformerMap> SourceTargetMap;
 
+  /**
+   * @brief Wrapper around tf::TransformListener to support non-TF transforms
+   *
+   * TransformManager is wraps tf::TransformListener and provides a similar
+   * interface to get Transforms between TF frames, UTM, and WGS84.
+   *
+   * TransformManager uses PluginLib to load all of the
+   * swri_transform_util::Transformer plugins it can find. To extend the
+   * functionality of TranformManager, create a new
+   * swri_transform_util::Transformer plugin that implements the desired transform.
+   */
   class TransformManager
   {
   public:
     TransformManager();
     ~TransformManager();
 
+    /**
+     * @brief Initialize the TransformManager with a tf::TransformListener
+     *
+     * The TransformManager must be initialized before it can be used.
+     *
+     * @param tf A shared pointer to a tf::TransformListener that the
+     *    Transformer wraps.
+     */
     void Initialize(boost::shared_ptr<tf::TransformListener> tf
         = boost::make_shared<tf::TransformListener>());
 
+    /**
+     * @brief Get the Transform between two frames at a specified time
+     *
+     * This function gets the transform from source_frame to target_frame at
+     * the specified time and returns it as a swri_transform_util::Transform.
+     *
+     * The frame IDs for target_frame and source_frame can be either a frame id
+     * in the current TF tree or one of the special frames /UTM or /WGS84.
+     *
+     * @param[in] target_frame The TF (or special) frame id of the target
+     * @param[in] source_frame The TF (or special) frame id of the source
+     * @param[in] time         The requested time to request the transform.
+     *    ros::Time(0) means the most recent time for which a valid transform
+     *    is available.
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated.
+     * @return True if the transform is supported and available at the
+     *    requested time. False otherwise.
+     */
     bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
         const ros::Time& time,
         Transform& transform) const;
 
+    /**
+     * @brief Get the most recent Transform between two frames
+     *
+     * This function gets the most recent transform from source_frame to
+     * target_frame and returns it as a swri_transform_util::Transform.
+     *
+     * The frame IDs for target_frame and source_frame can be either a frame id
+     * in the current TF tree or one of the special frames /UTM or /WGS84.
+     *
+     * @param[in] target_frame The TF (or special) frame id of the target
+     * @param[in] source_frame The TF (or special) frame id of the source
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated
+     * @return True if the transform is supported and available. False otherwise.
+     */
     bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
         Transform& transform) const;
 
+    /**
+     * @brief Check whether the TransformManager supports transforms from
+     *    source_frame to target_frame
+     *
+     * Supporting a transform does not imply that the TransformManager supports
+     * the inverse.
+     *
+     * @param[in] target_frame The TF (or special) frame id of the target
+     * @param[in] source_frame The TF (or special) frame id of the source
+     * @return True if the transform is supported. False if the transform is
+     *    unsupported.
+     */
     bool SupportsTransform(
         const std::string& target_frame,
         const std::string& source_frame) const;
 
+    /**
+     * @brief Get the tf::Transform between two frames at a specified time
+     *
+     * This function is a thin wrapper around the tf::TransformListener. Only
+     * TF frames are supported.
+     *
+     * @param[in] target_frame The TF frame id of the target
+     * @param[in] source_frame The TF frame id of the source
+     * @param[in] time         The requested time to request the transform.
+     *    ros::Time(0) means the most recent time for which a valid transform
+     *    is available.
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated.
+     * @return True if the transform is available at the requested time. False
+     *    otherwise.
+     */
     bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
         const ros::Time& time,
         tf::StampedTransform& transform) const;
 
+    /**
+     * @brief Get the most recent tf::Transform between two frames
+     *
+     * This function is a thin wrapper around the tf::TransformListener. Only
+     * TF frames are supported.
+     *
+     * @param[in] target_frame The TF frame id of the target
+     * @param[in] source_frame The TF frame id of the source
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated.
+     * @return True if the transform is available. False otherwise.
+     */
     bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,

--- a/swri_transform_util/include/swri_transform_util/transform_util.h
+++ b/swri_transform_util/include/swri_transform_util/transform_util.h
@@ -47,7 +47,7 @@ namespace swri_transform_util
       double reference_yaw);
 
   /**
-   * Calculates the great circle distance between two points.
+   * @brief Calculates the great circle distance between two points.
    *
    * @param[in] src_latitude   Source latitude
    * @param[in] src_longitude  Source longitude
@@ -63,7 +63,7 @@ namespace swri_transform_util
       double dst_longitude);
 
   /**
-   * Calculates the great circle distance between two points.
+   * @brief Calculates the great circle distance between two points.
    *
    * @param[in] src  Source(x = longitude, y = latitude, z ignored)
    * @param[in] dst  Destination(x = longitude, y = latitude, z ignored)
@@ -72,12 +72,31 @@ namespace swri_transform_util
    */
   double GreatCircleDistance(const tf::Vector3& src, const tf::Vector3& dst);
 
+  /**
+   * @brief Calculates the bearing between two points.
+   *
+   * @param[in] source_latitude       The latitude of the origin point in degrees
+   * @param[in] source_longitude      The longitude of the origin point in degrees
+   * @param[in] destination_latitude  The latitude of the destination point in degrees
+   * @param[in] destination_longitude The longitude of the destination point in degrees
+   * @return The bearing between the origin and destination in degrees ENU
+   */
   double GetBearing(
       double source_latitude,
       double source_longitude,
       double destination_latitude,
       double destination_longitude);
 
+  /**
+   * @brief Find the midpoint on the arc between two lat/lon points
+   *
+   * @param[in] latitude1      Endpoint 1 latitude in degrees
+   * @param[in] longitude1     Endpoint 1 longitude in degrees
+   * @param[in] latitude2      Endpoint 2 latitude in degrees
+   * @param[in] longitude2     Endpoint 2 longitude in degrees
+   * @param[out] mid_latitude  Midpoint latitude in degrees
+   * @param[out] mid_longitude Midpoint longitude in degrees
+   */
   void GetMidpointLatLon(
       double latitude1,
       double longitude1,

--- a/swri_transform_util/include/swri_transform_util/transformer.h
+++ b/swri_transform_util/include/swri_transform_util/transformer.h
@@ -43,6 +43,12 @@
 
 namespace swri_transform_util
 {
+  /**
+   * A base class for transformers.
+   *
+   * Instantiations of this class implement an interface to get transforms from
+   * certain types of frames (e.g. TF, WGS84) to other types of frames.
+   */
   class Transformer
   {
     public:
@@ -51,8 +57,27 @@ namespace swri_transform_util
 
       void Initialize(const boost::shared_ptr<tf::TransformListener> tf);
 
+      /**
+       * (pure virtual) Get a map of the transforms supported by this Transformer
+       * @return
+       */
       virtual std::map<std::string, std::vector<std::string> > Supports() const = 0;
 
+      /**
+       * (pure virtual) Get a swri_transform_util::Transform
+       *
+       * Gets the swri_transform_util::Transform that transforms coordinates
+       * from the source_frame into the target_frame. If the transform is not
+       * available, return false.
+       *
+       * @param[in] target_frame Destination frame for transform
+       * @param[in] source_frame Source frame for transform
+       * @param[in] time Time that the transform is valid for. To get the most
+       *    recent transform, use ros::Time(0)
+       * @param[out] transform Output container for the transform
+       * @return True if the transform was found, false if no transform between
+       *    the specified frames is available for the specified time.
+       */
       virtual bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,

--- a/swri_transform_util/include/swri_transform_util/transformer.h
+++ b/swri_transform_util/include/swri_transform_util/transformer.h
@@ -44,7 +44,7 @@
 namespace swri_transform_util
 {
   /**
-   * A base class for transformers.
+   * @brief A base class for transformers.
    *
    * Instantiations of this class implement an interface to get transforms from
    * certain types of frames (e.g. TF, WGS84) to other types of frames.
@@ -55,16 +55,26 @@ namespace swri_transform_util
       Transformer();
       virtual ~Transformer();
 
+      /**
+       * @brief Initialize the Transformer from a tf::TransformListener.
+       *
+       * @param tf A shared pointer to a tf::TransformListener that the
+       *    Transformer wraps. It is recommended that every Transformer in a
+       *    node use the same tf::TransformListener to reduce redundant
+       *    computation.
+       */
       void Initialize(const boost::shared_ptr<tf::TransformListener> tf);
 
       /**
-       * (pure virtual) Get a map of the transforms supported by this Transformer
-       * @return
+       * @brief Get a map of the transforms supported by this Transformer
+       * @return A map from source frame IDs to list of destination frame IDs.
+       *   A source->destination entry does not imply that the inverse
+       *   transform is supported as well.
        */
       virtual std::map<std::string, std::vector<std::string> > Supports() const = 0;
 
       /**
-       * (pure virtual) Get a swri_transform_util::Transform
+       * @brief Get a swri_transform_util::Transform
        *
        * Gets the swri_transform_util::Transform that transforms coordinates
        * from the source_frame into the target_frame. If the transform is not

--- a/swri_transform_util/include/swri_transform_util/utm_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/utm_transformer.h
@@ -45,13 +45,38 @@
 
 namespace swri_transform_util
 {
+  /**
+   * @brief Instantiation of Transformer to handle transforms to/from UTM
+   */
   class UtmTransformer : public Transformer
   {
     public:
       UtmTransformer();
 
+      /**
+       * @brief Get a map of the transforms supported by this Transformer
+       * @return A map from source frame IDs to list of destination frame IDs.
+       *   A source->destination entry does not imply that the inverse
+       *   transform is supported as well.
+       */
       virtual std::map<std::string, std::vector<std::string> > Supports() const;
 
+
+      /**
+       * @brief Get a Transform from a non-UTM frame to UTM or vice-versa
+       *
+       * Gets the swri_transform_util::Transform that transforms coordinates
+       * from the source_frame into the target_frame. If the transform is not
+       * available (or not supported), return false.
+       *
+       * @param[in] target_frame Destination frame for transform
+       * @param[in] source_frame Source frame for transform
+       * @param[in] time Time that the transform is valid for. To get the most
+       *    recent transform, use ros::Time(0)
+       * @param[out] transform Output container for the transform
+       * @return True if the transform was found, false if no transform between
+       *    the specified frames is available for the specified time.
+       */
       virtual bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
@@ -69,6 +94,13 @@ namespace swri_transform_util
       std::string local_xy_frame_;
   };
 
+
+  /**
+   * @brief Class to implement transformation from UTM to TF
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class UtmToTfTransform : public TransformImpl
   {
   public:
@@ -91,6 +123,13 @@ namespace swri_transform_util
     char utm_band_;
   };
 
+
+  /**
+   * @brief Class to implement transformation from TF to UTM
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class TfToUtmTransform : public TransformImpl
   {
   public:
@@ -109,6 +148,13 @@ namespace swri_transform_util
     boost::shared_ptr<LocalXyWgs84Util> local_xy_util_;
   };
 
+
+  /**
+   * @brief Class to implement transformation from UTM to WGS84
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class UtmToWgs84Transform : public TransformImpl
   {
   public:
@@ -125,6 +171,12 @@ namespace swri_transform_util
     char    utm_band_;
   };
 
+  /**
+   * @brief Class to implement transformation from WGS84 to UTM
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class Wgs84ToUtmTransform : public TransformImpl
   {
   public:

--- a/swri_transform_util/include/swri_transform_util/utm_util.h
+++ b/swri_transform_util/include/swri_transform_util/utm_util.h
@@ -39,10 +39,26 @@
 
 namespace swri_transform_util
 {
+  /**
+   * @brief Given a longitude angle, get the UTM zone
+   * @param longitude Longitude angle in degrees
+   * @return UTM zone number
+   */
   uint32_t GetZone(double longitude);
 
+  /**
+   * @brief Given a latitude angle, get the UTM band letter
+   * @param latitude Latitude angle in degrees
+   * @return UTM band letter
+   */
   char GetBand(double latitude);
 
+  /**
+   * @brief Utility class for converting between latitude/longitude and UTM
+   *
+   * Initialization of this class is costly, so it should be created on startup
+   * and reused.
+   */
   class UtmUtil
   {
   public:
@@ -90,8 +106,8 @@ namespace swri_transform_util
 
   private:
     /**
-     * The actual UTM conversion processing takes place in this helper class
-     * which is a singlton due to the large memory footprint of the underlying
+     * The actual UTM conversion processing takes place in this helper class,
+     * which is a singleton due to the large memory footprint of the underlying
      * PROJ.4 projections library structures.  Thread safety is enforced with
      * mutexes around the PROJ.4 functions, but could be achieved in the future
      * with a thread-safe version of PROJ.4 or ignored all together if the calls

--- a/swri_transform_util/include/swri_transform_util/utm_util.h
+++ b/swri_transform_util/include/swri_transform_util/utm_util.h
@@ -65,7 +65,7 @@ namespace swri_transform_util
     UtmUtil();
 
     /**
-     * Convert WGS84 latitude and longitude to UTM.
+     * @brief Convert WGS84 latitude and longitude to UTM.
      * 
      * @param[in]  latitude   Latitude value in degrees.
      * @param[in]  longitude  Longitude value in degrees.
@@ -79,7 +79,7 @@ namespace swri_transform_util
       int& zone, char& band, double& easting, double& northing) const;
 
     /**
-     * Convert WGS84 latitude and longitude to UTM.
+     * @brief Convert WGS84 latitude and longitude to UTM.
      * 
      * @param[in]  latitude   Latitude value in degrees.
      * @param[in]  longitude  Longitude value in degrees.
@@ -91,7 +91,7 @@ namespace swri_transform_util
       double& easting, double& northing) const;
 
     /**
-     * Convert UTM easting and northing to WGS84 latitude and longitude.
+     * @brief Convert UTM easting and northing to WGS84 latitude and longitude.
      *
      * @param[in]  zone       UTM zone.
      * @param[in]  band       UTM band.
@@ -118,14 +118,42 @@ namespace swri_transform_util
       public:
         ~UtmData();
 
+        /**
+         * @brief Convert WGS84 latitude and longitude to UTM.
+         *
+         * @param[in]  latitude   Latitude value in degrees.
+         * @param[in]  longitude  Longitude value in degrees.
+         * @param[out] zone       UTM zone number
+         * @param[out] band       UTM band letter
+         * @param[out] easting    UTM easting in meters.
+         * @param[out] northing   UTM northing in meters.
+         */
         void ToUtm(
           double latitude, double longitude,
           int& zone, char& band, double& easting, double& northing) const;
 
+        /**
+         * @brief Convert WGS84 latitude and longitude to UTM.
+         *
+         * @param[in]  latitude   Latitude value in degrees.
+         * @param[in]  longitude  Longitude value in degrees.
+         * @param[out] easting    UTM easting in meters.
+         * @param[out] northing   UTM northing in meters.
+         */
         void ToUtm(
           double latitude, double longitude,
           double& easting, double& northing) const;
 
+        /**
+         * @brief Convert UTM easting and northing to WGS84 latitude and longitude.
+         *
+         * @param[in]  zone       UTM zone.
+         * @param[in]  band       UTM band.
+         * @param[in]  easting    UTM easting in meters.
+         * @param[in]  northing   UTM northing in meters.
+         * @param[out] latitude   WGS84 latitude in degrees.
+         * @param[out] longitude  WGS84 longitude in degrees.
+         */
         void ToLatLon(
           int zone, char band, double easting, double northing,
           double& latitude, double& longitude) const;

--- a/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
@@ -44,13 +44,37 @@
 
 namespace swri_transform_util
 {
+  /***
+   * @brief Specialization of Transformer to perform transforms to/from WGS84
+   */
   class Wgs84Transformer : public Transformer
   {
     public:
       Wgs84Transformer();
 
+      /**
+       * @brief Get a map of the transforms supported by this Transformer
+       * @return A map from source frame IDs to list of destination frame IDs.
+       *   A source->destination entry does not imply that the inverse
+       *   transform is supported as well.
+       */
       virtual std::map<std::string, std::vector<std::string> > Supports() const;
 
+      /**
+       * @brief Get a Transform from a non-UTM frame to UTM or vice-versa
+       *
+       * Gets the swri_transform_util::Transform that transforms coordinates
+       * from the source_frame into the target_frame. If the transform is not
+       * available (or not supported), return false.
+       *
+       * @param[in] target_frame Destination frame for transform
+       * @param[in] source_frame Source frame for transform
+       * @param[in] time Time that the transform is valid for. To get the most
+       *    recent transform, use ros::Time(0)
+       * @param[out] transform Output container for the transform
+       * @return True if the transform was found, false if no transform between
+       *    the specified frames is available for the specified time.
+       */
       virtual bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
@@ -64,15 +88,51 @@ namespace swri_transform_util
       std::string local_xy_frame_;
   };
 
+  /**
+   * @brief Specialization of TransformImpl for transforming from TF to WGS84
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class TfToWgs84Transform : public TransformImpl
   {
-  public:    
+  public:
+    /**
+     * @brief Create a TfToWgs84Transform from a TF transform and local_xy_util
+     *
+     * @param[in] transform The TF transform to use as the source frame. This
+     *    transform should be the transform from the source frame to the local
+     *    XY origin frame
+     * @param local_xy_util A local XY Utility object to transform from the
+     *    local XY origin frame to WGS84 coordinates
+     */
     TfToWgs84Transform(
       const tf::StampedTransform& transform,
       boost::shared_ptr<LocalXyWgs84Util> local_xy_util);
 
+    /**
+     * @brief Transform a 3D vector to latitude/longitude
+     *
+     * The vector is first transformed with the `transform` into the local
+     * XY ortho-rectified frame. Then, the `local_xy_util` is used to convert
+     * to latitude/longitude.
+     *
+     * @param[in]  v_in  Input vector in the 'transform' parent frame.
+     * @param[out] v_out Output vector. x is the longitude in degrees, y is the
+     *    latitude in degrees, and z is the altitude in meters.
+     */
     virtual void Transform(const tf::Vector3& v_in, tf::Vector3& v_out) const;
 
+    /**
+     * @brief Get the orientation of the transform.
+     *
+     * This is calculated by transforming the reference angle of the
+     * `local_xy_util` using the `transform`. The result is the composition
+     * of those two rotations, which is the complete rotation from ENU frame
+     * to this frame.
+     *
+     * @return The orientation of the transform
+     */
     virtual tf::Quaternion GetOrientation() const;
 
   protected:
@@ -80,15 +140,51 @@ namespace swri_transform_util
     boost::shared_ptr<LocalXyWgs84Util> local_xy_util_;
   };
 
+  /**
+   * @brief Specialization of TransformImpl for transforming from WGS84 to TF
+   *
+   * This class should not be used directly. It is used internally by
+   * swri_transform_util::Transform
+   */
   class Wgs84ToTfTransform : public TransformImpl
   {
-  public:      
+  public:
+      /**
+       * @brief Create a Wgs84ToTfTransform from a TF transform and local_xy_util
+       *
+       * @param[in] transform The TF transform to use as the destination frame.
+       *    This transform should be the transform from the local XY origin
+       *    frame to the destination frame.
+       * @param local_xy_util A local XY Utility object to transform from WGS84
+       *    coordinates to the local XY origin frame
+       */
     Wgs84ToTfTransform(
       const tf::StampedTransform& transform,
       boost::shared_ptr<LocalXyWgs84Util> local_xy_util);
 
+    /**
+     * @brief Transform a WGS84 triple to a 3D vector
+     *
+     * The vector is first converted from latitude/longitude/altitude to the
+     * local XY ortho-rectified frame using the `local_xy_util`. Then, the
+     * `transform` is applied.
+     *
+     * @param[in]  v_in  Input vector. x is the longitude in degrees, y is the
+     *    latitude in degrees, and z is the altitude in meters.
+     * @param[out] v_out Output vector in the 'transform' child frame.
+     */
     virtual void Transform(const tf::Vector3& v_in, tf::Vector3& v_out) const;
 
+    /**
+     * @brief Get the orientation of the transform.
+     *
+     * This is calculated by transforming the inverse of the reference angle of
+     * the `local_xy_util` using the `transform`. The result is the composition
+     * of those two rotations, which is the complete rotation from this frame
+     * to the ENU frame.
+     *
+     * @return The orientation of the transform
+     */
     virtual tf::Quaternion GetOrientation() const;
 
   protected:

--- a/swri_transform_util/mainpage.dox
+++ b/swri_transform_util/mainpage.dox
@@ -11,7 +11,7 @@ such as accurate UTM calculations and transformation from local rectalinear
 frames to WGS84 lattitude/longitude and back.
 
 In addition to swri_transform_util::Transform, swri_transform_util provides
-swri_transform_util::Transformer, which wraps a tf::TransformListener and
+swri_transform_util::TransformManager, which wraps a tf::TransformListener and
 provides an interface to look up swri_transform_util::Transforms between TF
 frames and special frames, such as /wgs84 and /utm.
 

--- a/swri_transform_util/mainpage.dox
+++ b/swri_transform_util/mainpage.dox
@@ -1,17 +1,24 @@
 /**
 \mainpage
-\htmlinclude manifest.html
 
-\b ranger_common is ... 
+The swri_transform_util package contains utility functions and classes for
+transforming between coordinate frames.
 
-<!-- 
-Provide an overview of your package.
--->
+The primary function of the swri_transform_util package is to provide
+a swri_transform_util::Transform class similar to the tf::Transform class.
+The swri_transform_util::Transform can perform non-rectalinear transforms,
+such as accurate UTM calculations and transformation from local rectalinear
+frames to WGS84 lattitude/longitude and back.
 
+In addition to swri_transform_util::Transform, swri_transform_util provides
+swri_transform_util::Transformer, which wraps a tf::TransformListener and
+provides an interface to look up swri_transform_util::Transforms between TF
+frames and special frames, such as /wgs84 and /utm.
+
+<!--
 
 \section codeapi Code API
 
-<!--
 Provide links to specific auto-generated API documentation within your
 package that is of particular interest to a reader. Doxygen will
 document pretty much every part of your code, so do your best here to

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -38,6 +38,7 @@
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />
     <swri_transform_util plugin="${prefix}/transformer_plugins.xml" />
+    <rosdoc config="rosdoc.yaml" />
   </export>
 </package>
 

--- a/swri_transform_util/rosdoc.yaml
+++ b/swri_transform_util/rosdoc.yaml
@@ -2,4 +2,4 @@
 - builder: doxygen
   name: C++ API
   output_dir: c++
-  file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox'
+  file_patterns: '*.h *.dox'

--- a/swri_transform_util/rosdoc.yaml
+++ b/swri_transform_util/rosdoc.yaml
@@ -1,0 +1,5 @@
+---
+- builder: doxygen
+  name: C++ API
+  output_dir: c++
+  file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox'


### PR DESCRIPTION
This takes a chunk out of the effort to document `swri_transform` util. There's still a lot to be done, but this improves the `rosdoc` configuration and adds some more doxygen documentation for that package.

Refs (but does not close) #281 

