### PR TITLE
Initialize origin tests

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -93,7 +93,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
   target_link_libraries(test_transform_util ${PROJECT_NAME})
 
-  if($ENV{ROS_DISTRO} EQUAL "indigo")
+  if($ENV{ROS_DISTRO} STREQUAL "indigo")
     add_rostest(test/initialize_origin_auto_gps.test)
   else()  # Jade, Kinetic, Lunar, etc
     add_rostest(test/initialize_origin_auto_navsat.test)

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -92,6 +92,13 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
   target_link_libraries(test_transform_util ${PROJECT_NAME})
+
+  if($ENV{ROS_DISTRO} EQUAL "indigo")
+    add_rostest(test/initialize_origin_auto_gps.test)
+  else()  # Jade, Kinetic, Lunar, etc
+    add_rostest(test/initialize_origin_auto_navsat.test)
+  endif()
+  add_rostest(test/initialize_origin_manual.test)
 endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/swri_transform_util/test/initialize_origin_auto_gps.test
+++ b/swri_transform_util/test/initialize_origin_auto_gps.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="origin" pkg="swri_transform_util" type="initialize_origin.py">
+      <param name="local_xy_frame" value="/far_field"/>
+  </node>
+  <test
+      test-name="test_initialize_origin"
+      pkg="swri_transform_util"
+      type="test_initialize_origin.py"
+      args="auto_gps" />
+</launch>

--- a/swri_transform_util/test/initialize_origin_auto_navsat.test
+++ b/swri_transform_util/test/initialize_origin_auto_navsat.test
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="origin" pkg="swri_transform_util" type="initialize_origin.py">
+      <param name="local_xy_frame" value="/far_field"/>
+  </node>
+  <test
+      test-name="test_initialize_origin"
+      pkg="swri_transform_util"
+      type="test_initialize_origin.py"
+      args="auto_navsat" />
+</launch>

--- a/swri_transform_util/test/initialize_origin_manual.test
+++ b/swri_transform_util/test/initialize_origin_manual.test
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<launch>
+  <param name="local_xy_frame" value="/far_field"/>
+  <node name="origin" pkg="swri_transform_util" type="initialize_origin.py">
+    <rosparam>
+        local_xy_frame: /far_field
+        local_xy_origin: swri
+        local_xy_origins:
+          - {name: swri,
+             latitude: 29.45196669,
+             longitude: -98.61370577,
+             altitude: 233.719,
+             heading: 0.0}
+          - {name: back_40,
+             latitude: 29.447507,
+             longitude: -98.629367,
+             altitude: 200.0,
+             heading: 0.0}
+    </rosparam>
+  </node>
+  <test
+      test-name="test_initialize_origin"
+      pkg="swri_transform_util"
+      type="test_initialize_origin.py"
+      args="manual" />
+</launch>

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -77,7 +77,7 @@ class TestInitializeOrigin(unittest.TestCase):
             latitude = msg.latitude
             longitude = msg.longitude
             altitude = msg.altitude
-            self.assertEqual(heading, swri['heading'])
+            self.assertEqual(msg.track, swri['heading'])
         else:  # msg._type == GeoPose._type:
             latitude = msg.position.latitude
             longitude = msg.position.longitude

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -1,0 +1,132 @@
+#! /usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+from geometry_msgs.msg import PoseStamped
+from gps_common.msg import GPSFix
+from geographic_msgs.msg import GeoPose
+import rospy
+import rostest
+import rostopic
+from sensor_msgs.msg import NavSatFix
+import sys
+import unittest
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+ORIGIN_TYPES = [PoseStamped, GPSFix, GeoPose]
+
+swri = {
+    'latitude': 29.45196669,
+    'longitude': -98.61370577,
+    'altitude': 233.719,
+    'heading': 90
+}
+
+
+class TestInitializeOrigin(unittest.TestCase):
+    def subscribeToOrigin(self):
+        # This line blocks until initialize_origin is alive and has advertised the origin topic
+        origin_class = rostopic.get_topic_class(ORIGIN_TOPIC, blocking=True)[0]
+        rospy.loginfo("Origin is a " + origin_class._type + " message")
+        self.assertIsNotNone(origin_class, msg=ORIGIN_TOPIC+" was never advertised")
+        self.assertIn(origin_class, ORIGIN_TYPES)
+        return rospy.Subscriber(ORIGIN_TOPIC, origin_class, self.originCallback)        
+
+    def originCallback(self, msg):
+        if msg._type == PoseStamped._type:
+            latitude = msg.pose.position.y
+            longitude = msg.pose.position.x
+            altitude = msg.pose.position.z
+            # TODO: Extract heading
+        elif msg._type == GPSFix._type:
+            latitude = msg.latitude
+            longitude = msg.longitude
+            altitude = msg.altitude
+            heading = msg.track
+        else:  # msg._type == GeoPose._type:
+            latitude = msg.position.latitude
+            longitude = msg.position.longitude
+            altitude = msg.position.altitude
+            # TODO: Extract heading
+        self.assertEqual(msg.header.frame_id, '/far_field')
+        self.assertEqual(longitude, swri['longitude'])
+        self.assertEqual(latitude, swri['latitude'])
+        self.assertEqual(altitude, swri['altitude'])
+        self.assertEqual(heading, swri['heading'])
+        rospy.signal_shutdown("Test complete")
+
+
+class TestAutoOriginFromGPSFix(TestInitializeOrigin):
+    def testAutoOriginFromGPSFix(self):
+        rospy.init_node('test_initialize_origin')
+        gps_pub = rospy.Publisher('gps', GPSFix, queue_size=2)
+        origin_sub = self.subscribeToOrigin()
+        gps_msg = GPSFix()
+        gps_msg.latitude = swri['latitude']
+        gps_msg.longitude = swri['longitude']
+        gps_msg.altitude = swri['altitude']
+        gps_msg.track = swri['heading']
+        r = rospy.Rate(10.0)
+        while not rospy.is_shutdown():
+            gps_pub.publish(gps_msg)
+            r.sleep()
+
+
+class TestAutoOriginFromNavSatFix(TestInitializeOrigin):
+    def testAutoOriginFromNavSatFix(self):
+        rospy.init_node('test_initialize_origin')
+        nsf_pub = rospy.Publisher('gps', NavSatFix, queue_size=2)
+        origin_sub = self.subscribeToOrigin()
+        nsf_msg = NavSatFix()
+        nsf_msg.latitude = swri['latitude']
+        nsf_msg.longitude = swri['longitude']
+        nsf_msg.altitude = swri['altitude']
+        nsf_msg.header.frame_id = "/far_field"
+        r = rospy.Rate(10.0)
+        while not rospy.is_shutdown():
+            nsf_pub.publish(nsf_msg)
+            r.sleep()
+
+
+class TestManualOrigin(TestInitializeOrigin):
+    def testManualOrigin(self):
+        rospy.init_node('test_initialize_origin')
+        origin_sub = self.subscribeToOrigin()
+        rospy.spin()
+
+if __name__ == "__main__":
+    if sys.argv[1] == "auto_gps":
+        rostest.rosrun(PKG, NAME, TestAutoOriginFromGPSFix, sys.argv)
+    elif sys.argv[1] == "manual":
+        rostest.rosrun(PKG, NAME, TestManualOrigin, sys.argv)
+    elif sys.argv[1] == "auto_navsat":
+        rostest.rosrun(PKG, NAME, TestAutoOriginFromNavSatFix, sys.argv)
+

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -67,32 +67,32 @@ class TestInitializeOrigin(unittest.TestCase):
             longitude = msg.pose.position.x
             altitude = msg.pose.position.z
             quaternion = (msg.pose.orientation.x,
-                           msg.pose.orientation.x,
-                           msg.pose.orientation.x,
-                           msg.pose.orientation.x)
+                          msg.pose.orientation.y,
+                          msg.pose.orientation.z,
+                          msg.pose.orientation.w)
             euler = tf.transformations.euler_from_quaternion(quaternion)
             yaw = euler[2]
-            self.assertEqual(yaw, 0)
+            self.assertAlmostEqual(yaw, 0)
         elif msg._type == GPSFix._type:
             latitude = msg.latitude
             longitude = msg.longitude
             altitude = msg.altitude
-            self.assertEqual(msg.track, swri['heading'])
+            self.assertAlmostEqual(msg.track, swri['heading'])
         else:  # msg._type == GeoPose._type:
             latitude = msg.position.latitude
             longitude = msg.position.longitude
             altitude = msg.position.altitude
             quaternion = (msg.pose.orientation.x,
-                           msg.pose.orientation.x,
-                           msg.pose.orientation.x,
-                           msg.pose.orientation.x)
+                          msg.pose.orientation.y,
+                          msg.pose.orientation.z,
+                          msg.pose.orientation.w)
             euler = tf.transformations.euler_from_quaternion(quaternion)
             yaw = euler[2]
-            self.assertEqual(yaw, 0)
+            self.assertAlmostEqual(yaw, 0)
         self.assertEqual(msg.header.frame_id, '/far_field')
-        self.assertEqual(longitude, swri['longitude'])
-        self.assertEqual(latitude, swri['latitude'])
-        self.assertEqual(altitude, swri['altitude'])
+        self.assertAlmostEqual(longitude, swri['longitude'])
+        self.assertAlmostEqual(latitude, swri['latitude'])
+        self.assertAlmostEqual(altitude, swri['altitude'])
         rospy.signal_shutdown("Test complete")
 
 

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -35,6 +35,7 @@ import rostest
 import rostopic
 from sensor_msgs.msg import NavSatFix
 import sys
+import tf.transformations
 import unittest
 
 PKG = 'swri_transform_util'
@@ -65,22 +66,33 @@ class TestInitializeOrigin(unittest.TestCase):
             latitude = msg.pose.position.y
             longitude = msg.pose.position.x
             altitude = msg.pose.position.z
-            # TODO: Extract heading
+            quaternion = (msg.pose.orientation.x,
+                           msg.pose.orientation.x,
+                           msg.pose.orientation.x,
+                           msg.pose.orientation.x)
+            euler = tf.transformations.euler_from_quaternion(quaternion)
+            yaw = euler[2]
+            self.assertEqual(yaw, 0)
         elif msg._type == GPSFix._type:
             latitude = msg.latitude
             longitude = msg.longitude
             altitude = msg.altitude
-            heading = msg.track
+            self.assertEqual(heading, swri['heading'])
         else:  # msg._type == GeoPose._type:
             latitude = msg.position.latitude
             longitude = msg.position.longitude
             altitude = msg.position.altitude
-            # TODO: Extract heading
+            quaternion = (msg.pose.orientation.x,
+                           msg.pose.orientation.x,
+                           msg.pose.orientation.x,
+                           msg.pose.orientation.x)
+            euler = tf.transformations.euler_from_quaternion(quaternion)
+            yaw = euler[2]
+            self.assertEqual(yaw, 0)
         self.assertEqual(msg.header.frame_id, '/far_field')
         self.assertEqual(longitude, swri['longitude'])
         self.assertEqual(latitude, swri['latitude'])
         self.assertEqual(altitude, swri['altitude'])
-        self.assertEqual(heading, swri['heading'])
         rospy.signal_shutdown("Test complete")
 
 


### PR DESCRIPTION
Add some tests for `initialize_origin.py` in preparation for #452. These tests are far from exhaustive, but I think they're sufficient to test parameter API compatibility and interoperability with the CPP origin utilities.