### PR TITLE
[swri_image_util] Add a crosshairs nodelet to image_util

### DIFF
--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   swri_geometry_util
   swri_math_util
+  swri_nodelet
   swri_opencv_util
   tf
 )

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -86,6 +86,7 @@ target_link_libraries(${PROJECT_NAME}
 
 add_library(${PROJECT_NAME}_nodelets
   src/nodelets/blend_images_nodelet.cpp
+  src/nodelets/crosshairs_nodelet.cpp
   src/nodelets/contrast_stretch_nodelet.cpp
   src/nodelets/draw_text_nodelet.cpp
   src/nodelets/normalize_response_nodelet.cpp
@@ -118,6 +119,9 @@ target_link_libraries(normalize_response ${catkin_LIBRARIES})
 add_executable(blend_images src/nodes/blend_images_node.cpp)
 target_link_libraries(blend_images ${catkin_LIBRARIES})
 
+swri_nodelet_add_node(crosshairs ${PROJECT_NAME} CrosshairsNodelet)
+target_link_libraries(crosshairs ${PROJECT_NAME}_nodelets ${OpenCV_LIBRARIES} ${catkin_LIBRARIES})
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(test_geometry_util test/geometry_util.test test/test_geometry_util.cpp)
@@ -131,7 +135,8 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 install(TARGETS ${PROJECT_NAME} 
     ${PROJECT_NAME}_nodelets
-    normalization_image_generator_node 
+    normalization_image_generator_node
+    crosshairs
     dummy_image_publisher
     rotate_image
     scale_image

--- a/swri_image_util/nodelet_plugins.xml
+++ b/swri_image_util/nodelet_plugins.xml
@@ -1,20 +1,25 @@
 <library path="lib/libswri_image_util_nodelets">
-  
-  <class name="swri_image_util/rotate_image" type="swri_image_util::RotateImageNodelet" base_class_type="nodelet::Nodelet">
+
+  <class name="swri_image_util/blend_images" type="swri_image_util::BlendImagesNodelet" base_class_type="nodelet::Nodelet">
     <description>
-      Nodelet to rotate an image a multiple of 90 degrees.
+      Nodelet that blends one image onto the top of another.
     </description>
   </class>
-  
-  <class name="swri_image_util/scale_image" type="swri_image_util::ScaleImageNodelet" base_class_type="nodelet::Nodelet">
-    <description>
-      Nodelet to scale an image.
-    </description>
-  </class>
-  
+
   <class name="swri_image_util/contrast_stretch" type="swri_image_util::ContrastStretchNodelet" base_class_type="nodelet::Nodelet">
     <description>
       Nodelet to contrast stretch an image.
+    </description>
+  </class>
+
+  <class name="swri_image_util/crosshairs" type="swri_image_util::CrosshairsNodelet" base_class_type="nodelet::Nodelet">
+      <description> Nodelet that draws a crosshairs on an image.
+      </description>
+  </class>
+
+  <class name="swri_image_util/draw_text" type="swri_image_util::DrawTextNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to draw text on an image.
     </description>
   </class>
 
@@ -24,15 +29,15 @@
     </description>
   </class>
 
-  <class name="swri_image_util/draw_text" type="swri_image_util::DrawTextNodelet" base_class_type="nodelet::Nodelet">
+  <class name="swri_image_util/rotate_image" type="swri_image_util::RotateImageNodelet" base_class_type="nodelet::Nodelet">
     <description>
-      Nodelet to draw text on an image.
+      Nodelet to rotate an image a multiple of 90 degrees.
     </description>
   </class>
 
-  <class name="swri_image_util/blend_images" type="swri_image_util::BlendImagesNodelet" base_class_type="nodelet::Nodelet">
+  <class name="swri_image_util/scale_image" type="swri_image_util::ScaleImageNodelet" base_class_type="nodelet::Nodelet">
     <description>
-      Nodelet that blends one image onto the top of another.
+      Nodelet to scale an image.
     </description>
   </class>
   

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -28,6 +28,7 @@
   <depend>std_msgs</depend>
   <depend>swri_geometry_util</depend>
   <depend>swri_math_util</depend>
+  <build_depend>swri_nodelet</build_depend>
   <depend>swri_opencv_util</depend>
   <depend>tf</depend>
 

--- a/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
+++ b/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
@@ -66,11 +66,18 @@ namespace swri_image_util
     void ImageCallback(const sensor_msgs::ImageConstPtr& image)
     {
       cv_bridge::CvImagePtr cv_image = cv_bridge::toCvCopy(image);
+      // Get image dimensions
       const int h = cv_image->image.rows;
       const int w = cv_image->image.cols;
+      // Define line properties
       const cv::Scalar black(0, 0, 0);
-      cv::line(cv_image->image, cv::Point(0, w/2), cv::Point(h-1, w/2), black, 3, 8);
-      cv::line(cv_image->image, cv::Point(h/2, 0), cv::Point(h/2, w-1), black, 3, 8);
+      const int thickness = 3;
+      const int line_type = 8;  // 8-connected line
+      // Draw vertical line
+      cv::line(cv_image->image, cv::Point(0, w/2), cv::Point(h-1, w/2), black, thickness, line_type);
+      // Draw horizontal line
+      cv::line(cv_image->image, cv::Point(h/2, 0), cv::Point(h/2, w-1), black, thickness, line_type);
+      // Publish image
       image_pub_.publish(cv_image->toImageMsg());
     }
 

--- a/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
+++ b/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
@@ -1,0 +1,85 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <string>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <image_transport/image_transport.h>
+#include <sensor_msgs/image_encodings.h>
+#include <sensor_msgs/Image.h>
+#include <cv_bridge/cv_bridge.h>
+
+namespace swri_image_util
+{
+  class CrosshairsNodelet : public nodelet::Nodelet
+  {
+  public:
+    CrosshairsNodelet()
+    {
+    }
+
+    ~CrosshairsNodelet()
+    {
+    }
+
+    void onInit()
+    {
+      ros::NodeHandle &node = getNodeHandle();
+      ros::NodeHandle &priv = getPrivateNodeHandle();
+
+      image_transport::ImageTransport it(node);
+      image_pub_ = it.advertise("crosshairs_image", 1);
+      image_sub_ = it.subscribe("image", 1, &CrosshairsNodelet::ImageCallback, this);
+    }
+
+    void ImageCallback(const sensor_msgs::ImageConstPtr& image)
+    {
+      cv_bridge::CvImagePtr cv_image = cv_bridge::toCvCopy(image);
+      const int h = cv_image->image.rows;
+      const int w = cv_image->image.cols;
+      const cv::Scalar black(0, 0, 0);
+      cv::line(cv_image->image, cv::Point(0, w/2), cv::Point(h-1, w/2), black, 3, 8);
+      cv::line(cv_image->image, cv::Point(h/2, 0), cv::Point(h/2, w-1), black, 3, 8);
+      image_pub_.publish(cv_image->toImageMsg());
+    }
+
+  private:
+    image_transport::Subscriber image_sub_;
+    image_transport::Publisher image_pub_;
+  };
+}
+
+// Register nodelet plugin
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, CrosshairsNodelet);


### PR DESCRIPTION
This new node[let] `swri_image_util/crosshairs` draws a crosshairs in the center of an image and publishes the drawn-upon image for display in a tool such as `image_view`. This is useful for aligning things in the real world with the center of the image.

The majority of the changes to nodelet_plugins.xml are from alphabetizing the nodelets.