### PR TITLE
Fix extractSubroute in swri_route_util.

### DIFF
--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -707,7 +707,7 @@ bool extractSubroute(
   // Increment the end_index so that we can iterate from [start, end),
   // and make sure we stay within the array bounds.
   end_index++;
-  end_index = std::max(end_index, route.points.size());
+  end_index = std::min(end_index, route.points.size());
 
   sub_route.points.reserve(end_index - start_index);
   for (size_t i = start_index; i < end_index; i++) {


### PR DESCRIPTION
This commit fixes a bug where the check to make sure we don't overrun
an array was causing the extracted route to always include everything
after the start position instead of stopping at the end (std::max
where std::min is needed).