### PR TITLE
Color remapping

### DIFF
--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(${PROJECT_NAME}
   src/image_matching.cpp
   src/image_normalization.cpp 
   src/image_warp_util.cpp
+  src/replace_colors.cpp
   src/rolling_normalization.cpp 
 )
 target_link_libraries(${PROJECT_NAME} 
@@ -89,6 +90,7 @@ add_library(${PROJECT_NAME}_nodelets
   src/nodelets/contrast_stretch_nodelet.cpp
   src/nodelets/draw_text_nodelet.cpp
   src/nodelets/normalize_response_nodelet.cpp
+  src/nodelets/replace_colors_nodelet.cpp
   src/nodelets/rotate_image_nodelet.cpp
   src/nodelets/scale_image_nodelet.cpp
 )
@@ -118,6 +120,9 @@ target_link_libraries(normalize_response ${catkin_LIBRARIES})
 add_executable(blend_images src/nodes/blend_images_node.cpp)
 target_link_libraries(blend_images ${catkin_LIBRARIES})
 
+add_executable(replace_colors src/nodes/replace_colors.cpp)
+target_link_libraries(replace_colors ${catkin_LIBRARIES})
+
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   add_rostest_gtest(test_geometry_util test/geometry_util.test test/test_geometry_util.cpp)
@@ -138,6 +143,7 @@ install(TARGETS ${PROJECT_NAME}
     draw_text
     contrast_stretch
     normalize_response
+    replace_colors
     blend_images
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -147,4 +153,3 @@ install(TARGETS ${PROJECT_NAME}
 install(FILES nodelet_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-

--- a/swri_image_util/include/swri_image_util/replace_colors.h
+++ b/swri_image_util/include/swri_image_util/replace_colors.h
@@ -1,0 +1,47 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#ifndef IMAGE_UTIL_REPLACE_COLORS_H_
+#define IMAGE_UTIL_REPLACE_COLORS_H_
+
+#include <opencv2/core/core.hpp>
+
+namespace swri_image_util
+{
+  /**
+   * Replaces the colors in original_image with the values from the look up 
+   * table in lut. The modified image is stored in modified_image
+   */
+  void replaceColors(
+    const cv::Mat& original_image,
+    const cv::Mat& lut,
+    cv::Mat& modified_image);
+}
+
+#endif // IMAGE_UTIL_REPLACE_COLORS_H_

--- a/swri_image_util/launch/gray_to_hsv.launch
+++ b/swri_image_util/launch/gray_to_hsv.launch
@@ -1,0 +1,13 @@
+<launch>
+  <!-- Image blending options -->
+  <arg name="image" default="/class_max_prob" />
+
+  <node pkg="nodelet" type="nodelet" name="standalone_nodelet" args="manager" />
+  <node pkg="nodelet" type="nodelet" name="color_changer" args="load swri_image_util/replace_colors standalone_nodelet">
+    <remap from="image" to="$(arg image)" />
+    <!-- Recolor the image using 8 values from the HSV colormap -->
+    <rosparam param="colormap">
+      ["hsv", 8]
+    </rosparam>
+  </node>
+</launch>

--- a/swri_image_util/launch/replace_colors.launch
+++ b/swri_image_util/launch/replace_colors.launch
@@ -1,0 +1,12 @@
+<launch>
+  <!-- Image blending options -->
+  <arg name="image" default="/class_max_prob" />
+
+  <node pkg="nodelet" type="nodelet" name="standalone_nodelet" args="manager" />
+  <node pkg="nodelet" type="nodelet" name="color_changer" args="load swri_image_util/replace_colors standalone_nodelet">
+    <remap from="image" to="$(arg image)" />
+    <rosparam param="colors">
+      [[0, [0, 0, 0]], [1, [50, 50, 50]], [2, [100, 100, 100]], [3, [150, 150, 150]], [4, [200, 200, 200]], [5, [250, 250, 250]]]
+    </rosparam>
+  </node>
+</launch>

--- a/swri_image_util/nodelet_plugins.xml
+++ b/swri_image_util/nodelet_plugins.xml
@@ -36,4 +36,10 @@
     </description>
   </class>
   
+  <class name="swri_image_util/replace_colors" type="swri_image_util::ReplaceColorsNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet that replaces colors in an input image
+    </description>
+  </class>
+  
 </library>

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -131,7 +131,8 @@ namespace swri_image_util
     // This node has two different methods of changing gray scale values to
     // color imagery. The first maps the gray scale values to OpenCV colormaps
     // This call checks for that option
-    if (priv_nh.getParam("colormap", color_param))
+    bool colormap_specified = priv_nh.getParam("colormap", color_param);
+    if (colormap_specified)
     {
       //  Use the colormap the user has requested
       readColormap(color_param);
@@ -148,9 +149,9 @@ namespace swri_image_util
       // Try to read in the lookup values from the parameter server.
       readUserLut(color_param);
     }
-    else
+    else if (!colormap_specified)
     {
-      ROS_ERROR("LUT for color transformation was not specified. Images will ");
+      ROS_ERROR("Color transformation was not specified. Images will ");
       ROS_ERROR("only be converted to their gray scale equivalents");
     }
 
@@ -336,7 +337,6 @@ namespace swri_image_util
         color_lut_.at<cv::Vec3b>(0, static_cast<uint8_t>(replace_idx)) = 
           original_colors.at<cv::Vec3b>(0, static_cast<uint8_t>(lookup_idx));
       }
-
     }
   }
 

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -137,7 +137,13 @@ namespace swri_image_util
         ROS_ERROR("LUT entries must be two entry arrays");
         return false;
       }
+
       XmlRpc::XmlRpcValue map_key = lut_row[0];
+      if (map_key.getType() != XmlRpc::XmlRpcValue::TypeInt)
+      {
+        ROS_ERROR("Color to replace must be an integer");
+      }
+
       XmlRpc::XmlRpcValue rgb_values = lut_row[1];
       if ((rgb_values.getType() != XmlRpc::XmlRpcValue::TypeArray) || 
         (rgb_values.size() != 3) ||
@@ -149,12 +155,13 @@ namespace swri_image_util
         return false;
       }
 
-      cv::Vec3b rgb_entry(
-        static_cast<uint8_t>(static_cast<int32_t>(rgb_values[0])),
-        static_cast<uint8_t>(static_cast<int32_t>(rgb_values[1])),
-        static_cast<uint8_t>(static_cast<int32_t>(rgb_values[2])));
-      color_lut_.at<cv::Vec3b>(0, static_cast<uint8_t>(
-        static_cast<int32_t>(map_key))) = rgb_entry;
+      uint8_t color_index = static_cast<uint8_t>(static_cast<int32_t>(map_key));
+      uint8_t red = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[0]));
+      uint8_t green = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[1]));
+      uint8_t blue = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[2]));
+
+      cv::Vec3b rgb_entry(red, green, blue);
+      color_lut_.at<cv::Vec3b>(0, color_index) = rgb_entry;
     }
   }
 }

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -1,0 +1,78 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <ros/ros.h>
+#include <image_transport/image_transport.h>
+#include <cv_bridge/cv_bridge.h>
+#include <nodelet/nodelet.h>
+#include <sensor_msgs/Image.h>
+#include <swri_image_util/replace_colors.h>
+
+namespace swri_image_util
+{
+  class ReplaceColorsNodelet : public nodelet::Nodelet
+  {
+  public:
+    ReplaceColorsNodelet();
+    ~ReplaceColorsNodelet();
+  
+  private:
+    virtual void onInit();
+    void imageCallback(const sensor_msgs::ImageConstPtr& image_msg);
+
+    cv::Mat color_lut_;
+    image_transport::Publisher image_pub_;
+  };
+
+  ReplaceColorsNodelet::ReplaceColorsNodelet()
+  {
+  }
+
+  ReplaceColorsNodelet::~ReplaceColorsNodelet()
+  {
+  }
+
+  void ReplaceColorsNodelet::onInit()
+  {
+
+  }
+
+  void ReplaceColorsNodelet::imageCallback(
+    const sensor_msgs::ImageConstPtr& image_msg)
+  {
+
+  }
+}
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_DECLARE_CLASS(
+  swri_image_util,
+  replace_colors,
+  swri_image_util::ReplaceColorsNodelet,
+  nodelet::Nodelet)

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -26,7 +26,6 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 // *****************************************************************************
-
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
@@ -37,6 +36,10 @@
 
 namespace swri_image_util
 {
+  const int32_t MAX_GRAY_VALUE = 255;
+  const int32_t MAX_RGB_VALUE = 255;
+
+  // ROS nodelet for replacing colors in an image
   class ReplaceColorsNodelet : public nodelet::Nodelet
   {
   public:
@@ -44,21 +47,33 @@ namespace swri_image_util
     ~ReplaceColorsNodelet();
   
   private:
+    // Does the actual initialization since this is a nodelet
     virtual void onInit();
+    // Callback for the input image
     void imageCallback(const sensor_msgs::ImageConstPtr& image_msg);
+    // Initialize the lookup table
+    void initLut();
+    // Helper function for getting color mapping frC++ static cast to unsigned charom parameter server
     bool readLut(const XmlRpc::XmlRpcValue &param);
 
+    // Lookup table defining color replacement strategy. The row indices 
+    // correspond to the gray scale values, and the values in the rows are RGB
+    // values to replace the gray scale values with
     cv::Mat color_lut_;
+    // Publishes the modified image
     image_transport::Publisher image_pub_;
+    // Subscribes to the original image
     image_transport::Subscriber image_sub_;
   };
 
   ReplaceColorsNodelet::ReplaceColorsNodelet()
   {
+    // All initialization is deferred to the onInit() call
   }
 
   ReplaceColorsNodelet::~ReplaceColorsNodelet()
   {
+    // Nothing to clean up on destruction
   }
 
   void ReplaceColorsNodelet::onInit()
@@ -67,19 +82,33 @@ namespace swri_image_util
     ros::NodeHandle& nh = getNodeHandle();
     ros::NodeHandle& priv_nh  = getPrivateNodeHandle();
 
+    // Lookup table to replace colors with. By default will just convert the
+    // gray scale values to their RGB equivalents. If this node is ever extended
+    // to more than gray scale, this will have to be changed
     color_lut_ = cv::Mat::zeros(1, 256, CV_8UC3);
+    initLut();
 
+    // Get the array representing the color mapping from the parameter server.
+    // This will be in the format [[u0, [r0, g0, b0]], [u1, [r1, g1, b1]]]
+    // where u is the gray scale value to replace, and r, g, b are the RGB
+    // components to replace it with.
     XmlRpc::XmlRpcValue color_param;
     if (priv_nh.getParam("colors", color_param))
     {
-      readLut(color_param);
+      // Try to read in the lookup values from the parameter server. Reset the
+      // values if this operation fails
+      if (!readLut(color_param))
+      {
+        initLut();
+      }
     }
     else
     {
-      ROS_ERROR("LUT for color transformation must be specified");
-      ROS_BREAK();
+      ROS_ERROR("LUT for color transformation was not specified. Images will ");
+      ROS_ERROR("only be converted to their gray scale equivalents");
     }
 
+    // Set up the ROS interface
     image_transport::ImageTransport it(nh);
     image_pub_ = it.advertise("modified_image", 1);
     image_sub_ = it.subscribe(
@@ -89,9 +118,17 @@ namespace swri_image_util
       this);
   }
 
+  // Callback for getting the input image to change the colors on
   void ReplaceColorsNodelet::imageCallback(
     const sensor_msgs::ImageConstPtr& image_msg)
   {
+    // Only do the color conversion if someone is subscribing to the data
+    if (image_pub_.getNumSubscribers() == 0)
+    {
+      return;
+    }
+
+    // This node currently only support changing gray scale images
     if (image_msg->encoding != sensor_msgs::image_encodings::MONO8)
     {
       ROS_ERROR("Changing image colors is only supported for MONO8 images");
@@ -101,49 +138,86 @@ namespace swri_image_util
     // Convert image data from ROS to OpenCV type
     cv_bridge::CvImageConstPtr original_image = cv_bridge::toCvShare(image_msg);
 
-    // Allocate space for the new image
+    // Allocate space for the modified image
     cv::Mat modified_image = cv::Mat::zeros(
       original_image->image.rows,
       original_image->image.cols,
       CV_8UC3);
 
+    // Do the actual color replacement
     swri_image_util::replaceColors(
       original_image->image,
       color_lut_,
       modified_image);
 
+    // Copy results to output message and set up the header and encoding values
     cv_bridge::CvImagePtr output = boost::make_shared<cv_bridge::CvImage>();
     output->image = modified_image;
     output->encoding = sensor_msgs::image_encodings::RGB8;
     output->header = image_msg->header;
 
+    // Publish the modified image to the rest of the system
     image_pub_.publish(output->toImageMsg());
+  }
+
+  void ReplaceColorsNodelet::initLut()
+  {
+    for (uint32_t idx; idx < 256; idx++)
+    {
+      color_lut_.at<cv::Vec3b>(0, idx) = cv::Vec3b(idx, idx, idx);
+    }
   }
 
   bool ReplaceColorsNodelet::readLut(const XmlRpc::XmlRpcValue& param)
   {
+    // Assume the parameter parsing works by default
+    bool success = true;
     if (param.getType() != XmlRpc::XmlRpcValue::TypeArray)
     {
       ROS_ERROR("LUT must be an array");
-      return false;
+      success = false;
     }
 
-    for (uint32_t lut_idx = 0; lut_idx < param.size(); lut_idx++)
+    // Loop over all values that will be replaced. The casting in here is 
+    // complicated because XmlRpc cannot go directly from the parameters to 
+    // uint8_t values, so they must first be cast to int32_t, and then to the
+    // smaller value
+    for (uint32_t lut_idx = 0; success && (lut_idx < param.size()); lut_idx++)
     {
+      // Each row will be of the form [key, [r, g, b]]
       XmlRpc::XmlRpcValue lut_row = param[lut_idx];
       if ((lut_row.getType() != XmlRpc::XmlRpcValue::TypeArray) ||
         (lut_row.size() != 2))
       {
         ROS_ERROR("LUT entries must be two entry arrays");
-        return false;
+        success = false;
+        break;
       }
 
+      // The first element in the gray scale value to replace. Make sure it
+      // is of the appropriate type
       XmlRpc::XmlRpcValue map_key = lut_row[0];
       if (map_key.getType() != XmlRpc::XmlRpcValue::TypeInt)
       {
         ROS_ERROR("Color to replace must be an integer");
+        success = false;
+        break;
       }
 
+      // Make sure the gray scale index is in the proper range
+      int32_t gray_index = static_cast<int32_t>(map_key);
+      if (gray_index > MAX_GRAY_VALUE)
+      {
+        ROS_ERROR("Gray scale index must be less than %d", MAX_GRAY_VALUE);
+        success = false;
+        break;
+      }
+
+      // Convert to the value used to index into the LUT
+      uint8_t color_index = static_cast<uint8_t>(gray_index);
+
+      // Now read the RGB values. There must be three of them, they must be
+      // integers, and less than 256
       XmlRpc::XmlRpcValue rgb_values = lut_row[1];
       if ((rgb_values.getType() != XmlRpc::XmlRpcValue::TypeArray) || 
         (rgb_values.size() != 3) ||
@@ -152,18 +226,46 @@ namespace swri_image_util
         (rgb_values[2].getType() != XmlRpc::XmlRpcValue::TypeInt))
       {
         ROS_ERROR("RGB entries must be three entry arrays of integers");
-        return false;
+        success = false;
+        break;
       }
 
-      uint8_t color_index = static_cast<uint8_t>(static_cast<int32_t>(map_key));
-      uint8_t red = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[0]));
-      uint8_t green = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[1]));
-      uint8_t blue = static_cast<uint8_t>(static_cast<int32_t>(rgb_values[2]));
+      // Make sure the RGB values are less than 256
+      int32_t original_red = static_cast<int32_t>(rgb_values[0]);
+      if (original_red > MAX_RGB_VALUE)
+      {
+        ROS_ERROR("Red values must be less than %d", MAX_RGB_VALUE);
+        success = false;
+        break;
+      }
+      int32_t original_green = static_cast<int32_t>(rgb_values[1]);
+      if (original_green > MAX_RGB_VALUE)
+      {
+        ROS_ERROR("Green values must be less than %d", MAX_RGB_VALUE);
+        success = false;
+        break;
+      }
+      int32_t original_blue = static_cast<int32_t>(rgb_values[2]);
+      if (original_blue > MAX_RGB_VALUE)
+      {
+        ROS_ERROR("Blue values must be less than %d", MAX_RGB_VALUE);
+        success = false;
+        break;
+      }
 
+      // Get the RGB values to the correct type
+      uint8_t red = static_cast<uint8_t>(original_red);
+      uint8_t green = static_cast<uint8_t>(original_green);
+      uint8_t blue = static_cast<uint8_t>(original_blue);
+
+      // Convert the RGB values to OpenCV types and put them in the LUT
       cv::Vec3b rgb_entry(red, green, blue);
       color_lut_.at<cv::Vec3b>(0, color_index) = rgb_entry;
     }
+    
+    return success;
   }
+
 }
 
 #include <pluginlib/class_list_macros.h>

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -353,7 +353,7 @@ namespace swri_image_util
 
     // Make a copy of the current LUT. The copy will be modified, and only
     // if the complete parameter reading works will the real LUT be modified.
-    cv::Mat temp_lut = color_lut_;
+    cv::Mat temp_lut = color_lut_.clone();
 
     // Loop over all values that will be replaced. The casting in here is 
     // complicated because XmlRpc cannot go directly from the parameters to 
@@ -444,7 +444,7 @@ namespace swri_image_util
     // copied back to the persistent LUT.
     if (success)
     {
-      color_lut_ = temp_lut;
+      color_lut_ = temp_lut.clone();
     }
   }
 }

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -27,6 +27,9 @@
 //
 // *****************************************************************************
 #include <opencv2/core/version.hpp>
+#if CV_MAJOR_VERSION == 2
+#include <opencv2/contrib/contrib.hpp>
+#endif
 #include <opencv2/imgproc/imgproc.hpp>
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>

--- a/swri_image_util/src/nodes/replace_colors.cpp
+++ b/swri_image_util/src/nodes/replace_colors.cpp
@@ -1,0 +1,48 @@
+
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <ros/ros.h>
+#include <nodelet/loader.h>
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "replace_colors", ros::init_options::AnonymousName);
+  nodelet::Loader manager(false);
+
+  nodelet::M_string remappings;
+  nodelet::V_string my_argv;
+  manager.load(
+    ros::this_node::getName(),
+    "swri_image_util/replace_colors",
+    remappings,
+    my_argv);
+    ros::spin();
+    return 0;
+}

--- a/swri_image_util/src/replace_colors.cpp
+++ b/swri_image_util/src/replace_colors.cpp
@@ -30,6 +30,8 @@
 #include <ros/ros.h>
 #include <swri_image_util/replace_colors.h>
 
+#include <opencv2/imgproc/imgproc.hpp>
+
 namespace swri_image_util
 {
   void replaceColors(
@@ -37,6 +39,8 @@ namespace swri_image_util
     const cv::Mat& lut,
     cv::Mat& modified_image)
   {
-
+    cv::Mat input_rgb;
+    cv::cvtColor(original_image, input_rgb, CV_GRAY2BGR);
+    cv::LUT(input_rgb, lut, modified_image);
   }
 }

--- a/swri_image_util/src/replace_colors.cpp
+++ b/swri_image_util/src/replace_colors.cpp
@@ -1,0 +1,42 @@
+// *****************************************************************************
+//
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// *****************************************************************************
+
+#include <ros/ros.h>
+#include <swri_image_util/replace_colors.h>
+
+namespace swri_image_util
+{
+  void replaceColors(
+    const cv::Mat& original_image,
+    const cv::Mat& lut,
+    cv::Mat& modified_image)
+  {
+
+  }
+}


### PR DESCRIPTION
Cleaned up version of #460 

Resolves #459. Adds a node for arbitrarily replacing the colors in a gray scale image with RGB values.