### PR TITLE
Revert "Remove nodelet_plugins.xml from CMakeLists.txt"

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -111,3 +111,6 @@ install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_nodelets lat_lon_tf_echo
 catkin_install_python(PROGRAMS nodes/initialize_origin.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
+install(FILES nodelet_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)


### PR DESCRIPTION
This reverts commit ae6c1bb7e18812c66235d146bb862d6a0be26a7c.

Fixes #474.

I haven't had a chance to test this out, and I definitely want some eyes on this, because I introduced the bug in question.