### PR TITLE
Add CI lint, better CI organization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
       script:
-        - sudo apt-get update -qq && sudo apt-get -qq -y install python-catkin-lint
+        - sudo pip install catkin-lint
         - catkin_lint -W2 --explain
       env: JOB="catkin_lint"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ jobs:
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
-      script:
-        - sudo pip install -q catkin-lint
-        - catkin_lint -W2 --explain .
+      sudo: false
+      install: pip install -q catkin-lint
+      script: catkin_lint -W2 --explain .
       env: JOB="catkin_lint"
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ jobs:
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
       script:
-        - sudo pip install catkin-lint
-        - catkin_lint -W2 --explain
+        - sudo pip install -q catkin-lint
+        - catkin_lint -W2 --explain .
       env: JOB="catkin_lint"
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
       script:
-        - apt-get update -qq && apt-get -qq -y install python-catkin-lint
+        - sudo apt-get update -qq && sudo apt-get -qq -y install python-catkin-lint
         - catkin_lint -W2 --explain
       env: JOB="catkin_lint"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,33 @@
-sudo: required 
-dist: trusty 
+sudo: required
+dist: trusty
 language: generic
-compiler:
-  - clang
-  - gcc
+
 notifications:
   email:
     on_success: always
     on_failure: always
-env:
-  matrix:
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-matrix:
+
+install: git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script: source .ci_config/travis.sh
+
+jobs:
+  include:
+    - stage: build-shadow-fixed
+      env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - stage: build-released
+      env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - stage: lint
+      script: catkin_lint -W2 --explain
+      env: JOB="catkin_lint"
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
-script: 
-  - source .ci_config/travis.sh
-#  - source ./travis.sh  # Enable this when you have a package-local script 
+    - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: JOB="catkin_lint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ jobs:
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
-      script: catkin_lint -W2 --explain
+      script:
+        - apt-get update -qq && apt-get -qq -y install python-catkin-lint
+        - catkin_lint -W2 --explain
       env: JOB="catkin_lint"
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu


### PR DESCRIPTION
- Use Travis's new Stages and Jobs instead of Matrix
- Add a lint job to run catkin_lint on the repository
- Prioritize required jobs over jobs that are allowed to fail