### PR TITLE
Add bounds checking to extractSubroute.

### DIFF
--- a/swri_route_util/include/swri_route_util/util.h
+++ b/swri_route_util/include/swri_route_util/util.h
@@ -134,6 +134,7 @@ bool routeDistances(
   const std::vector<marti_nav_msgs::RoutePosition> &ends,
   const Route &route);
 
+// Extracts a subroute from [start, end)
 bool extractSubroute(
   Route &sub_route,
   const Route &route,

--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -711,6 +711,8 @@ bool extractSubroute(
 
   if (end_index <= start_index)
   {
+    sub_route.points.clear();
+    sub_route.rebuildPointIndex();
     return true;
   }
 

--- a/swri_route_util/src/util.cpp
+++ b/swri_route_util/src/util.cpp
@@ -709,6 +709,11 @@ bool extractSubroute(
   end_index++;
   end_index = std::min(end_index, route.points.size());
 
+  if (end_index <= start_index)
+  {
+    return true;
+  }
+
   sub_route.points.reserve(end_index - start_index);
   for (size_t i = start_index; i < end_index; i++) {
     sub_route.points.push_back(route.points[i]);


### PR DESCRIPTION
Add bounds checking to extractSubroute to handle start and end positions being out of order.