### PR TITLE
Complete rewrite of initialize_origin.py

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -17,6 +17,8 @@ find_package(catkin REQUIRED COMPONENTS
   topic_tools
 )
 
+catkin_python_setup()
+
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
@@ -88,11 +90,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
   target_link_libraries(test_transform_util ${PROJECT_NAME})
 
-  if($ENV{ROS_DISTRO} STREQUAL "indigo")
-    add_rostest(test/initialize_origin_auto_gps.test)
-  else()  # Jade, Kinetic, Lunar, etc
-    add_rostest(test/initialize_origin_auto_navsat.test)
-  endif()
+  add_rostest(test/initialize_origin_auto_gps.test)
+  add_rostest(test/initialize_origin_auto_navsat.test)
   add_rostest(test/initialize_origin_manual.test)
 endif()
 

--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -63,7 +63,7 @@ local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
 manager = OriginManager(local_xy_frame)
 if local_xy_origin == "auto":
     gps_sub = rospy.Subscriber("gps", GPSFix, queue_size=2)
-    navsat_sub = rospy.Subscriber("navsatfix", NavSatFix, queue_size=2)
+    navsat_sub = rospy.Subscriber("fix", NavSatFix, queue_size=2)
     gps_sub.impl.add_callback(gps_callback,
                               (manager, gps_sub, navsat_sub)) # Extra arguments to callback)
     navsat_sub.impl.add_callback(navsat_callback,

--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -28,11 +28,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
 from gps_common.msg import GPSFix
 import rospy
 from sensor_msgs.msg import NavSatFix
 from swri_transform_util.origin_manager import OriginManager, InvalidFixException
+
 
 def navsat_callback(msg, (manager, navsat_sub, gps_sub)):
         try:
@@ -41,9 +41,10 @@ def navsat_callback(msg, (manager, navsat_sub, gps_sub)):
             rospy.logwarn(e)
             return
         finally:
-            rospy.loginfo("Got NavSat message. Setting origin and unsubscribing from NavSat.")
+            rospy.loginfo('Got NavSat message. Setting origin and unsubscribing from NavSat.')
             navsat_sub.unregister()
             gps_sub.unregister()
+
 
 def gps_callback(msg, (manager, gps_sub, navsat_sub)):
         try:
@@ -52,7 +53,7 @@ def gps_callback(msg, (manager, gps_sub, navsat_sub)):
             rospy.logwarn(e)
             return
         finally:
-            rospy.loginfo("Got GPSFix message. Setting origin and unsubscribing from GPSFix.")
+            rospy.loginfo('Got GPSFix message. Setting origin and unsubscribing from GPSFix.')
             gps_sub.unregister()
             navsat_sub.unregister()
 
@@ -61,23 +62,25 @@ rospy.init_node('initialize_origin', anonymous=True)
 local_xy_frame = rospy.get_param('~local_xy_frame', 'map')
 local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
 manager = OriginManager(local_xy_frame)
-if local_xy_origin == "auto":
-    gps_sub = rospy.Subscriber("gps", GPSFix, queue_size=2)
-    navsat_sub = rospy.Subscriber("fix", NavSatFix, queue_size=2)
+if local_xy_origin == 'auto':
+    gps_sub = rospy.Subscriber('gps', GPSFix, queue_size=2)
+    navsat_sub = rospy.Subscriber('fix', NavSatFix, queue_size=2)
     gps_sub.impl.add_callback(gps_callback,
-                              (manager, gps_sub, navsat_sub)) # Extra arguments to callback)
+                              (manager, gps_sub, navsat_sub))  # Extra arguments to callback
     navsat_sub.impl.add_callback(navsat_callback,
-                                 (manager, navsat_sub, gps_sub)) # Extra arguments to callback
+                                 (manager, navsat_sub, gps_sub))  # Extra arguments to callback
 else:
     try:
         origin_list = rospy.get_param('~local_xy_origins')
     except KeyError:
-        rospy.logfatal('local_xy_frame is "{}", but local_xy_origins is not specified'.format(local_xy_frame))
+        message = 'local_xy_frame is "{}", but local_xy_origins is not specified'
+        rospy.logfatal(message.format(local_xy_frame))
         exit(1)
     try:
         manager.set_origin_from_list(local_xy_origin, origin_list)
     except (TypeError, KeyError) as e:
-        rospy.logfatal('local_xy_origins is malformed or does not contain the local_xy_frame "{}"'.format(local_xy_frame))
+        message = 'local_xy_origins is malformed or does not contain the local_xy_frame "{}"'
+        rospy.logfatal(message.format(local_xy_frame))
         rospy.logfatal(e)
         exit(1)
 manager.start()

--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2013-2017, Southwest Research Institute® (SwRI®)
+# Copyright (C) 2017, Southwest Research Institute® (SwRI®)
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #
@@ -28,280 +28,57 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import rospy
-import tf
-from diagnostic_msgs.msg import DiagnosticArray
-from diagnostic_msgs.msg import DiagnosticStatus
-from diagnostic_msgs.msg import KeyValue
 
-from geometry_msgs.msg import PoseStamped
 from gps_common.msg import GPSFix
+import rospy
 from sensor_msgs.msg import NavSatFix
+from swri_transform_util.origin_manager import OriginManager, InvalidFixException
 
-# Global variables
-_origin = None
-_gps_fix = None
+def navsat_callback(msg, (manager, navsat_sub, gps_sub)):
+        try:
+            manager.set_origin_from_navsat(msg)
+        except InvalidFixException as e:
+            rospy.logwarn(e)
+            return
+        finally:
+            rospy.loginfo("Got NavSat message. Setting origin and unsubscribing from NavSat.")
+            navsat_sub.unregister()
+            gps_sub.unregister()
 
-def make_origin_msg(frame_id, latitude, longitude, altitude):
-    origin = PoseStamped()
-    origin.header.frame_id = frame_id
-    origin.pose.position.y = latitude
-    origin.pose.position.x = longitude
-    origin.pose.position.z = altitude
-    # Heading is always 0
-    origin.pose.orientation.x = 0.0
-    origin.pose.orientation.y = 0.0
-    origin.pose.orientation.z = 0.0
-    origin.pose.orientation.w = 1.0
-    return origin
+def gps_callback(msg, (manager, gps_sub, navsat_sub)):
+        try:
+            manager.set_origin_from_gps(msg)
+        except InvalidFixException as e:
+            rospy.logwarn(e)
+            return
+        finally:
+            rospy.loginfo("Got GPSFix message. Setting origin and unsubscribing from GPSFix.")
+            gps_sub.unregister()
+            navsat_sub.unregister()
 
-def parse_origin(local_xy_origin):
-    global _gps_fix
 
-    local_xy_origins = rospy.get_param('~local_xy_origins', [])
-
-    for origin in local_xy_origins:
-        if origin["name"] == local_xy_origin:
-
-            _gps_fix = GPSFix()
-            _gps_fix.header.frame_id = _local_xy_frame
-            _gps_fix.status.header.frame_id = local_xy_origin
-            _gps_fix.latitude = origin["latitude"]
-            _gps_fix.longitude = origin["longitude"]
-            _gps_fix.altitude = origin["altitude"]
-            _gps_fix.track = 90
-
-            _origin_pub.publish(_gps_fix)
-
-def make_origin_from_list(frame_id, origin_name, origin_list):
-    if len(origin_list) == 0:
-        rospy.logwarn("No origins specified--defaulting to auto")
-        return None
-    if len(origin_list) == 1:
-        origin = origin_list[0]
-        return make_origin_msg(frame_id,
-                               origin["latitude"],
-                               origin["longitude"],
-                               origin["altitude"])
-    for origin in origin_list:
-        if origin["name"] == origin_name:
-            return make_origin_msg(frame_id,
-                                   origin["latitude"],
-                                   origin["longitude"],
-                                   origin["altitude"])
-    rospy.logerror('Origin "{}" is not in the origin list. Available origins are {}.'.format(origin_name, ",".join(['"{}"'.format(x.name) for x in origin_list])))
-    rospy.logerror("No origin found--defaulting to auto")
-    return None
-
-def navsatfix_callback(data, (frame_id, pub, sub)):
-    if data.status.status == -1:
-        # This fix is invalid, ignore it and wait until we get a valid one
-        rospy.logwarn("Got invalid fix.  Waiting for a valid one...")
-        return
-    global _origin
-    rospy.loginfo("Got NavSat message. Setting origin and unsubscribing from NavSat.")
-    sub.unregister()
-    if _origin is None:
-        _origin = make_origin_msg(frame_id,
-                                  data.latitude,
-                                  data.longitude,
-                                  data.altitude)
-        pub.publish(_origin)
-
-def gps_callback(data):
-    if data.status.status == -1:
-        # This fix is invalid, ignore it and wait until we get a valid one
-        rospy.logwarn("Got invalid fix.  Waiting for a valid one...")
-        return
-    global _gps_fix
-
-    if _gps_fix == None:
-        global _sub
-        _sub.unregister()
-        _sub = None
-
-        _gps_fix = data
-        _gps_fix.header.frame_id = _local_xy_frame
-        _gps_fix.track = 90
-
-        _origin_pub.publish(_gps_fix)
-
-def make_diagnostic(origin, static_origin):
-    diagnostic = DiagnosticArray()
-    diagnostic.header.stamp = rospy.Time.now()
-    status = DiagnosticStatus()
-    status.name = "LocalXY Origin"
-    status.hardware_id = "origin_publisher"
-    if origin == None:
-        status.level = DiagnosticStatus.ERROR
-        status.message = "No Origin"
-    else:
-        if not static_origin:
-            status.level = DiagnosticStatus.OK
-            status.message = "Has Origin (auto)"
-        else:
-            status.level = DiagnosticStatus.WARN
-            status.message = "Origin is static (non-auto)"
-        
-        frame_id = origin.header.frame_id
-        status.values.append(KeyValue(key="Origin Frame ID", value=frame_id))
-        
-        latitude = "%f" % origin.pose.position.y
-        status.values.append(KeyValue(key="Latitude", value=latitude))
-        
-        longitude = "%f" % origin.pose.position.x
-        status.values.append(KeyValue(key="Longitude", value=longitude))
-        
-        altitude = "%f" % origin.pose.position.z
-        status.values.append(KeyValue(key="Altitude", value=altitude))
-    
-    diagnostic.status.append(status)
-    return diagnostic
-
-def initialize_origin():
-    global _origin
-    rospy.init_node('initialize_origin', anonymous=True)
-
-    ros_distro = os.environ.get('ROS_DISTRO')
-
-    if not ros_distro:
-        rospy.logerror('ROS_DISTRO environment variable was not set.')
-        exit(1)
-
-    if ros_distro == 'indigo':
-        # ROS Indigo uses the GPSFix message 
-        global _origin_pub
-        global _local_xy_frame
-        _origin_pub = rospy.Publisher('/local_xy_origin', GPSFix, latch=True, queue_size=2)
-    
-        diagnostic_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=2)
-    
-        local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
-        _local_xy_frame = rospy.get_param('~local_xy_frame', 'map')
-        _local_xy_frame_identity = rospy.get_param('~local_xy_frame_identity', _local_xy_frame + "__identity")
-    
-        if local_xy_origin == "auto":
-            global _sub
-            _sub = rospy.Subscriber("gps", GPSFix, gps_callback)
-        else:
-            parse_origin(local_xy_origin)
-    
-        if len(_local_xy_frame):
-            tf_broadcaster = tf.TransformBroadcaster()
-        else:
-            tf_broadcaster = None
-    
-        hw_id = rospy.get_param('~hw_id', 'none')
-    
-        while not rospy.is_shutdown():
-            if tf_broadcaster:
-                # Publish transform involving map (to an anonymous unused
-                # frame) so that TransformManager can support /tf<->/wgs84
-                # conversions without requiring additional nodes.
-                tf_broadcaster.sendTransform(
-                    (0, 0, 0),
-                    (0, 0, 0, 1),
-                    rospy.Time.now(),
-                    _local_xy_frame_identity, _local_xy_frame)
-    
-            if _gps_fix == None:
-                diagnostic = DiagnosticArray()
-                diagnostic.header.stamp = rospy.Time.now()
-    
-                status = DiagnosticStatus()
-    
-                status.name = "LocalXY Origin"
-                status.hardware_id = hw_id
-    
-                status.level = DiagnosticStatus.ERROR
-                status.message = "No Origin"
-    
-                diagnostic.status.append(status)
-    
-                diagnostic_pub.publish(diagnostic)
-            else:
-                _origin_pub.publish(_gps_fix) # Publish this at 1Hz for bag convenience
-                diagnostic = DiagnosticArray()
-                diagnostic.header.stamp = rospy.Time.now()
-    
-                status = DiagnosticStatus()
-    
-                status.name = "LocalXY Origin"
-                status.hardware_id = hw_id
-    
-                if local_xy_origin == 'auto':
-                    status.level = DiagnosticStatus.OK
-                    status.message = "Has Origin (auto)"
-                else:
-                    status.level = DiagnosticStatus.WARN
-                    status.message = "Origin is static (non-auto)"
-    
-                value0 = KeyValue()
-                value0.key = "Origin"
-                value0.value = _gps_fix.status.header.frame_id
-                status.values.append(value0)
-    
-                value1 = KeyValue()
-                value1.key = "Latitude"
-                value1.value = "%f" % _gps_fix.latitude
-                status.values.append(value1)
-    
-                value2 = KeyValue()
-                value2.key = "Longitude"
-                value2.value = "%f" % _gps_fix.longitude
-                status.values.append(value2)
-    
-                value3 = KeyValue()
-                value3.key = "Altitude"
-                value3.value = "%f" % _gps_fix.altitude
-                status.values.append(value3)
-    
-                diagnostic.status.append(status)
-    
-                diagnostic_pub.publish(diagnostic)
-            rospy.sleep(1.0)
-    else:
-        # ROS distros later than Indigo use NavSatFix
-        origin_pub = rospy.Publisher('/local_xy_origin', PoseStamped, latch=True, queue_size=2)
-        diagnostic_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=2)
-        origin_name = rospy.get_param('~local_xy_origin', 'auto')
-        rospy.loginfo('Local XY origin is "' + origin_name + '"')
-        origin_frame_id = rospy.get_param(rospy.search_param('local_xy_frame'), 'map')
-        origin_frame_identity = rospy.get_param('~local_xy_frame_identity', origin_frame_id + "__identity")
-        rospy.loginfo('Local XY frame ID is "' + origin_frame_id + '"')
-        
-        if len(origin_frame_id):
-            tf_broadcaster = tf.TransformBroadcaster()
-        else:
-            tf_broadcaster = None
-    
-        if origin_name != "auto":
-            origin_list = rospy.get_param('~local_xy_origins', [])
-            _origin = make_origin_from_list(origin_frame_id, origin_name, origin_list)
-            if _origin is not None:
-                origin_pub.publish(_origin)
-            else:
-                origin_name = "auto"
-        if origin_name == "auto":
-            sub = rospy.Subscriber("gps", NavSatFix)
-            sub.impl.add_callback(navsatfix_callback, (origin_frame_id, origin_pub, sub))
-            rospy.loginfo('Subscribed to NavSat on ' + sub.resolved_name)
-        while not rospy.is_shutdown():
-            if tf_broadcaster:
-                # Publish transform involving map (to an anonymous unused
-                # frame) so that TransformManager can support /tf<->/wgs84
-                # conversions without requiring additional nodes.
-                tf_broadcaster.sendTransform(
-                    (0, 0, 0),
-                    (0, 0, 0, 1),
-                    rospy.Time.now(),
-                    origin_frame_identity, origin_frame_id)
-    
-            diagnostic_pub.publish(make_diagnostic(_origin, origin_name != "auto"))
-            rospy.sleep(1.0)
-
-if __name__ == '__main__':
+rospy.init_node('initialize_origin', anonymous=True)
+local_xy_frame = rospy.get_param('~local_xy_frame', 'map')
+local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
+manager = OriginManager(local_xy_frame)
+if local_xy_origin == "auto":
+    gps_sub = rospy.Subscriber("gps", GPSFix, queue_size=2)
+    navsat_sub = rospy.Subscriber("navsatfix", NavSatFix, queue_size=2)
+    gps_sub.impl.add_callback(gps_callback,
+                              (manager, gps_sub, navsat_sub)) # Extra arguments to callback)
+    navsat_sub.impl.add_callback(navsat_callback,
+                                 (manager, navsat_sub, gps_sub)) # Extra arguments to callback
+else:
     try:
-        initialize_origin()
-    except rospy.ROSInterruptException: pass
+        origin_list = rospy.get_param('~local_xy_origins')
+    except KeyError:
+        rospy.logfatal('local_xy_frame is "{}", but local_xy_origins is not specified'.format(local_xy_frame))
+        exit(1)
+    try:
+        manager.set_origin_from_list(local_xy_origin, origin_list)
+    except (TypeError, KeyError) as e:
+        rospy.logfatal('local_xy_origins is malformed or does not contain the local_xy_frame "{}"'.format(local_xy_frame))
+        rospy.logfatal(e)
+        exit(1)
+manager.start()
+rospy.spin()

--- a/swri_transform_util/setup.py
+++ b/swri_transform_util/setup.py
@@ -1,0 +1,13 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['swri_transform_util'],
+    package_dir={'': 'src'},
+    requires=['diagnostic_msgs', 'geometry_msgs', 'gps_common', 'rospy', 'sensor_msgs', 'tf']
+)
+
+setup(**setup_args)

--- a/swri_transform_util/src/swri_transform_util/origin_manager.py
+++ b/swri_transform_util/src/swri_transform_util/origin_manager.py
@@ -118,7 +118,7 @@ class OriginManager(object):
                                               queue_size=2)
         self.tf_broadcaster = tf.TransformBroadcaster()
 
-    def set_origin(self, latitude, longitude, altitude):
+    def set_origin(self, latitude, longitude, altitude, stamp=None):
         """
         Set the origin to the position described by the arguments and publish it.
 
@@ -129,9 +129,14 @@ class OriginManager(object):
             longitude (float): The longitude of the origin in degrees.
             altitude (float): The altitude of the origin in meters.
                 Positive values correspond to altitude above the geoid.
+            stamp (rospy.Time): The time to use for the origin's header.stamp field.
+                If the argument is `None`, the stamp is not set and defaults to
+                `rospy.Time(0)`. (default None).
         """
         origin = PoseStamped()
         origin.header.frame_id = self.local_xy_frame
+        if stamp is not None:
+            origin.header.stamp = stamp
         origin.pose.position.y = latitude
         origin.pose.position.x = longitude
         origin.pose.position.z = altitude
@@ -195,7 +200,7 @@ class OriginManager(object):
         if msg.status.status == GPSStatus.STATUS_NO_FIX:
             message = 'Cannot set origin from invalid GPSFix. Waiting for a valid one...'
             raise InvalidFixException(message)
-        self.set_origin(msg.latitude, msg.longitude, msg.altitude)
+        self.set_origin(msg.latitude, msg.longitude, msg.altitude, msg.header.stamp)
         self.origin_source = 'gpsfix'
 
     def set_origin_from_navsat(self, msg):
@@ -211,7 +216,7 @@ class OriginManager(object):
         if msg.status.status == NavSatStatus.STATUS_NO_FIX:
             message = 'Cannot set origin from invalid NavSatFix. Waiting for a valid one...'
             raise InvalidFixException(message)
-        self.set_origin(msg.latitude, msg.longitude, msg.altitude)
+        self.set_origin(msg.latitude, msg.longitude, msg.altitude, msg.header.stamp)
         self.origin_source = 'navsat'
 
     def _publish_diagnostic(self):

--- a/swri_transform_util/src/swri_transform_util/origin_manager.py
+++ b/swri_transform_util/src/swri_transform_util/origin_manager.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+"""A module containing a simple class for publishing the Local XY origin as a PoseStamped."""
+
 # Copyright (C) 2017, Southwest Research Institute® (SwRI®)
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -36,22 +38,97 @@ import tf
 
 
 class InvalidFixException(Exception):
+    """Exception to throw when a GPSFix or NavSatFix message does not contain a valid fix."""
+
     pass
 
 
 class OriginManager(object):
+    """
+    A simple class for publishing the Local XY origin as a PoseStamped.
+
+    Creates publishers to `/local_xy_origin` (geometry_msgs/PoseStamped)
+    and `/diagnostics` (diagnostic_msgs/DiagnosticArray). Publishes an
+    identity TF from the origin to support /tf<->/wgs84 conversions.
+
+    Usage (manual origin):
+        manager = OriginManager("/map")
+        manager.set_origin(29.45196669, -98.61370577, 233.719)
+        manager.start()
+
+    Usage (manual origin from parameter):
+        local_xy_origin = rospy.get_param('~local_xy_origin')
+        manager = OriginManager("map")
+        origin_list = rospy.get_param('~local_xy_origins')
+        manager.start()
+
+    Usage (auto origin from NavSatFix):
+        def navsat_callback(msg, (manager, navsat_sub)):
+            try:
+                manager.set_origin_from_navsat(msg)
+            except InvalidFixException as e:
+                rospy.logwarn(e)
+                return
+            finally:
+                navsat_sub.unregister()
+        manager = OriginManager("/map")
+        navsat_sub = rospy.Subscriber("fix", NavSatFix, queue_size=2)
+        navsat_sub.impl.add_callback(navsat_callback, (manager, navsat_sub))
+        manager.start()
+
+    Usage (auto origin from GPSFix):
+        def gps_callback(msg, (manager, gps_sub)):
+            try:
+                manager.set_origin_from_gps(msg)
+            except InvalidFixException as e:
+                rospy.logwarn(e)
+                return
+            finally:
+                gps_sub.unregister()
+        manager = OriginManager("/map")
+        gps_sub = rospy.Subscriber("gps", GPSFix, queue_size=2)
+        gps_sub.impl.add_callback(gps_callback, (manager, gps_sub))
+        manager.start()
+    """
+
     def __init__(self, local_xy_frame, local_xy_frame_identity=None):
+        """
+        Construct an OriginManager, create publishers and TF Broadcaster.
+
+        Args:
+            local_xy_frame (str): TF frame ID of the local XY origin
+            local_xy_frame_identity (str): TF frame ID of the identity frame published
+                to enable tf<->/wgs_84 conversions in systems with no other frames. If
+                this argument is `None`, `local_xy_frame` + "__identity" is used.
+                (default None).
+        """
         self.origin = None
         self.origin_source = None
         self.local_xy_frame = local_xy_frame
         if local_xy_frame_identity is None:
             local_xy_frame_identity = local_xy_frame + "__identity"
         self.local_xy_frame_identity = local_xy_frame_identity
-        self.origin_pub = rospy.Publisher('/local_xy_origin', PoseStamped, latch=True, queue_size=2)
-        self.diagnostic_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=2)
+        self.origin_pub = rospy.Publisher('/local_xy_origin',
+                                          PoseStamped,
+                                          latch=True,
+                                          queue_size=2)
+        self.diagnostic_pub = rospy.Publisher('/diagnostics',
+                                              DiagnosticArray,
+                                              queue_size=2)
         self.tf_broadcaster = tf.TransformBroadcaster()
 
     def set_origin(self, latitude, longitude, altitude):
+        """
+        Set the origin to the position described by the arguments and publish it.
+
+        All other set_ methods wrap this method.
+
+        Args:
+            latitude (float): The latitude of the origin in degrees.
+            longitude (float): The longitude of the origin in degrees.
+            altitude (float): The altitude of the origin in meters.
+                Positive values correspond to altitude above the geoid.
+        """
         origin = PoseStamped()
         origin.header.frame_id = self.local_xy_frame
         origin.pose.position.y = latitude
@@ -66,22 +143,54 @@ class OriginManager(object):
         self.origin_pub.publish(self.origin)
 
     def set_origin_from_dict(self, origin_dict):
+        """
+        Set the local origin from a dictionary.
+
+        Args:
+            origin_dict (dict): A dictionary containing the keys "latitude", "longitude", and
+                "altitude" with appropriate float values
+
+        Raises:
+            KeyError: If `origin_dict` does not contain all of the required keys.
+        """
         self.origin = self.set_origin(origin_dict["latitude"],
                                       origin_dict["longitude"],
                                       origin_dict["altitude"])
         self.origin_source = "manual"
 
     def set_origin_from_list(self, origin_name, origin_list):
+        """
+        Set the local origin from a list of named origins.
+
+        Args:
+            origin_name (str): The name of the origin in origin_list to use
+            origin_list (list): A list of dicts containing a name key and all keys required
+                by set_origin_from_dict()
+
+        Raises:
+            KeyError: If any origin in `origins_list` lacks a "name" key or if there exists
+                no origin in `origins_list` whose "name" is `origin_name`
+        """
         for origin in origin_list:
             if origin['name'] == origin_name:
                 self.set_origin_from_dict(origin)
                 return
         else:
             origins_list_str = ','.join(['"{}"'.format(x.name) for x in origin_list])
-            message = 'Origin "{}" is not in the origin list. Available origins are {}.'
+            message = 'Origin "{}" is not in the origin list. Available origins are '.format(
+                origin_name, origins_list_str)
             raise KeyError(message)
 
     def set_origin_from_gps(self, msg):
+        """
+        Set the local origin from a gps_common.msg.GPSFix object.
+
+        Args:
+            msg (gps_common.msg.GPSFix): A GPSFix message with the local origin
+
+        Raises:
+            InvalidFixException: If `msg.status.status` is STATUS_NO_FIX
+        """
         if msg.status.status == GPSStatus.STATUS_NO_FIX:
             message = 'Cannot set origin from invalid GPSFix. Waiting for a valid one...'
             raise InvalidFixException(message)
@@ -89,13 +198,23 @@ class OriginManager(object):
         self.origin_source = 'gpsfix'
 
     def set_origin_from_navsat(self, msg):
+        """
+        Set the local origin from a sensor_msgs.msg.NavSatFix object.
+
+        Args:
+            msg (sensor_msgs.msg.NavSatFix): A NavSatFix message with the local origin
+
+        Raises:
+            InvalidFixException: If `msg.status.status` is STATUS_NO_FIX
+        """
         if msg.status.status == NavSatStatus.STATUS_NO_FIX:
             message = 'Cannot set origin from invalid NavSatFix. Waiting for a valid one...'
             raise InvalidFixException(message)
         self.set_origin(msg.latitude, msg.longitude, msg.altitude)
         self.origin_source = 'navsat'
-    
+
     def _publish_diagnostic(self):
+        """Publish diagnostics."""
         diagnostic = DiagnosticArray()
         diagnostic.header.stamp = rospy.Time.now()
         status = DiagnosticStatus()
@@ -133,7 +252,7 @@ class OriginManager(object):
     def _publish_identity_tf(self):
         """
         Publish a transform from the map frame to an anonymous unused frame.
-        
+
         This allows the TransformManager to support /tf<->/wgs84 conversions
         without requiring additional nodes.
         """
@@ -144,8 +263,22 @@ class OriginManager(object):
                                           self.local_xy_frame)
 
     def spin_once(self, timer_event=None):
+        """
+        Publish identity transform and diagnostics.
+
+        This method can be called as a rospy timer callback.
+
+        Args:
+            timer_event (rospy.TimerEvent): This event is unused. (default None)
+        """
         self._publish_identity_tf()
         self._publish_diagnostic()
 
     def start(self, period=rospy.Duration(1.0)):
+        """
+        Start a rospy Timer thread to call spin_once() with the given duration.
+
+        Args:
+            period (rospy.Duration): spin_once() is called at this rate.
+        """
         self.timer = rospy.Timer(period, self.spin_once)

--- a/swri_transform_util/src/swri_transform_util/origin_manager.py
+++ b/swri_transform_util/src/swri_transform_util/origin_manager.py
@@ -60,6 +60,7 @@ class OriginManager(object):
         local_xy_origin = rospy.get_param('~local_xy_origin')
         manager = OriginManager("map")
         origin_list = rospy.get_param('~local_xy_origins')
+        manager.set_origin_from_list(local_xy_origin, origin_list)
         manager.start()
 
     Usage (auto origin from NavSatFix):

--- a/swri_transform_util/src/swri_transform_util/origin_manager.py
+++ b/swri_transform_util/src/swri_transform_util/origin_manager.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2017, Southwest Research Institute® (SwRI®)
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
+from geometry_msgs.msg import PoseStamped
+from gps_common.msg import GPSStatus
+import rospy
+from sensor_msgs.msg import NavSatStatus
+import tf
+
+
+class InvalidFixException(Exception):
+    pass
+
+
+class OriginManager(object):
+    def __init__(self, local_xy_frame, local_xy_frame_identity=None):
+        self.origin = None
+        self.origin_source = None
+        self.local_xy_frame = local_xy_frame
+        if local_xy_frame_identity is None:
+            local_xy_frame_identity = local_xy_frame + "__identity"
+        self.local_xy_frame_identity = local_xy_frame_identity
+        self.origin_pub = rospy.Publisher('/local_xy_origin', PoseStamped, latch=True, queue_size=2)
+        self.diagnostic_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size=2)
+        self.tf_broadcaster = tf.TransformBroadcaster()
+
+    def set_origin(self, latitude, longitude, altitude):
+        origin = PoseStamped()
+        origin.header.frame_id = self.local_xy_frame
+        origin.pose.position.y = latitude
+        origin.pose.position.x = longitude
+        origin.pose.position.z = altitude
+        # Heading is always 0
+        origin.pose.orientation.x = 0.0
+        origin.pose.orientation.y = 0.0
+        origin.pose.orientation.z = 0.0
+        origin.pose.orientation.w = 1.0
+        self.origin = origin
+        self.origin_pub.publish(self.origin)
+
+    def set_origin_from_dict(self, origin_dict):
+        self.origin = self.set_origin(origin_dict["latitude"],
+                                      origin_dict["longitude"],
+                                      origin_dict["altitude"])
+        self.origin_source = "manual"
+
+    def set_origin_from_list(self, origin_name, origin_list):
+        for origin in origin_list:
+            if origin['name'] == origin_name:
+                self.set_origin_from_dict(origin)
+                return
+        else:
+            origins_list_str = ','.join(['"{}"'.format(x.name) for x in origin_list])
+            message = 'Origin "{}" is not in the origin list. Available origins are {}.'
+            raise KeyError(message)
+
+    def set_origin_from_gps(self, msg):
+        if msg.status.status == GPSStatus.STATUS_NO_FIX:
+            message = 'Cannot set origin from invalid GPSFix. Waiting for a valid one...'
+            raise InvalidFixException(message)
+        self.set_origin(msg.latitude, msg.longitude, msg.altitude)
+        self.origin_source = 'gpsfix'
+
+    def set_origin_from_navsat(self, msg):
+        if msg.status.status == NavSatStatus.STATUS_NO_FIX:
+            message = 'Cannot set origin from invalid NavSatFix. Waiting for a valid one...'
+            raise InvalidFixException(message)
+        self.set_origin(msg.latitude, msg.longitude, msg.altitude)
+        self.origin_source = 'navsat'
+    
+    def _publish_diagnostic(self):
+        diagnostic = DiagnosticArray()
+        diagnostic.header.stamp = rospy.Time.now()
+        status = DiagnosticStatus()
+        status.name = "LocalXY Origin"
+        status.hardware_id = "origin_publisher"
+        if self.origin is None:
+            status.level = DiagnosticStatus.ERROR
+            status.message = "No Origin"
+        else:
+            if self.origin_source == "gpsfix":
+                status.level = DiagnosticStatus.OK
+                status.message = "Has Origin (GPSFix)"
+            elif self.origin_source == "navsat":
+                status.level = DiagnosticStatus.OK
+                status.message = "Has Origin (NavSatFix)"
+            else:
+                status.level = DiagnosticStatus.WARN
+                status.message = "Origin Was Set Manually"
+
+            frame_id = self.origin.header.frame_id
+            status.values.append(KeyValue(key="Origin Frame ID", value=frame_id))
+
+            latitude = "%f" % self.origin.pose.position.y
+            status.values.append(KeyValue(key="Latitude", value=latitude))
+
+            longitude = "%f" % self.origin.pose.position.x
+            status.values.append(KeyValue(key="Longitude", value=longitude))
+
+            altitude = "%f" % self.origin.pose.position.z
+            status.values.append(KeyValue(key="Altitude", value=altitude))
+
+            diagnostic.status.append(status)
+            self.diagnostic_pub.publish(diagnostic)
+
+    def _publish_identity_tf(self):
+        """
+        Publish a transform from the map frame to an anonymous unused frame.
+        
+        This allows the TransformManager to support /tf<->/wgs84 conversions
+        without requiring additional nodes.
+        """
+        self.tf_broadcaster.sendTransform((0, 0, 0),
+                                          (0, 0, 0, 1),
+                                          rospy.Time.now(),
+                                          self.local_xy_frame_identity,
+                                          self.local_xy_frame)
+
+    def spin_once(self, timer_event=None):
+        self._publish_identity_tf()
+        self._publish_diagnostic()
+
+    def start(self, period=rospy.Duration(1.0)):
+        self.timer = rospy.Timer(period, self.spin_once)

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -44,6 +44,7 @@ NAME = 'test_initialize_origin'
 ORIGIN_TOPIC = '/local_xy_origin'
 ORIGIN_TYPES = [PoseStamped, GPSFix, GeoPose]
 
+msg_stamp = rospy.Time(1337, 0xDEADBEEF)
 swri = {
     'latitude': 29.45196669,
     'longitude': -98.61370577,
@@ -59,6 +60,7 @@ class TestInitializeOrigin(unittest.TestCase):
         rospy.loginfo("Origin is a " + origin_class._type + " message")
         self.assertIsNotNone(origin_class, msg=ORIGIN_TOPIC+" was never advertised")
         self.assertIn(origin_class, ORIGIN_TYPES)
+        self.test_stamp = False  # Enable this for auto origin
         return rospy.Subscriber(ORIGIN_TOPIC, origin_class, self.originCallback)        
 
     def originCallback(self, msg):
@@ -90,6 +92,10 @@ class TestInitializeOrigin(unittest.TestCase):
             yaw = euler[2]
             self.assertAlmostEqual(yaw, 0)
         self.assertEqual(msg.header.frame_id, '/far_field')
+        if self.test_stamp:
+            self.assertEqual(msg.header.stamp, msg_stamp)
+        else:
+            self.assertEqual(msg.header.stamp, rospy.Time(0))
         self.assertAlmostEqual(longitude, swri['longitude'])
         self.assertAlmostEqual(latitude, swri['latitude'])
         self.assertAlmostEqual(altitude, swri['altitude'])
@@ -101,11 +107,13 @@ class TestAutoOriginFromGPSFix(TestInitializeOrigin):
         rospy.init_node('test_initialize_origin')
         gps_pub = rospy.Publisher('gps', GPSFix, queue_size=2)
         origin_sub = self.subscribeToOrigin()
+        self.test_stamp = True
         gps_msg = GPSFix()
         gps_msg.latitude = swri['latitude']
         gps_msg.longitude = swri['longitude']
         gps_msg.altitude = swri['altitude']
         gps_msg.track = swri['heading']
+        gps_msg.header.stamp = msg_stamp
         r = rospy.Rate(10.0)
         while not rospy.is_shutdown():
             gps_pub.publish(gps_msg)
@@ -117,11 +125,13 @@ class TestAutoOriginFromNavSatFix(TestInitializeOrigin):
         rospy.init_node('test_initialize_origin')
         nsf_pub = rospy.Publisher('fix', NavSatFix, queue_size=2)
         origin_sub = self.subscribeToOrigin()
+        self.test_stamp = True
         nsf_msg = NavSatFix()
         nsf_msg.latitude = swri['latitude']
         nsf_msg.longitude = swri['longitude']
         nsf_msg.altitude = swri['altitude']
         nsf_msg.header.frame_id = "/far_field"
+        nsf_msg.header.stamp = msg_stamp
         r = rospy.Rate(10.0)
         while not rospy.is_shutdown():
             nsf_pub.publish(nsf_msg)

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -115,7 +115,7 @@ class TestAutoOriginFromGPSFix(TestInitializeOrigin):
 class TestAutoOriginFromNavSatFix(TestInitializeOrigin):
     def testAutoOriginFromNavSatFix(self):
         rospy.init_node('test_initialize_origin')
-        nsf_pub = rospy.Publisher('gps', NavSatFix, queue_size=2)
+        nsf_pub = rospy.Publisher('fix', NavSatFix, queue_size=2)
         origin_sub = self.subscribeToOrigin()
         nsf_msg = NavSatFix()
         nsf_msg.latitude = swri['latitude']


### PR DESCRIPTION
Add a new Python module `origin_manager` to `swri_transform_util`. `origin_manager` defines a Python class `OriginManager` that can be used to manage the local XY origin. initialize_origin.py is now a wrapper around an OriginManager object.

All tests should pass to maintain previous behavior of initialize_origin.py.

This PR is WIP pending proper documentation, but I'd like to open this to review and CI.

Closes #452 