### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/swri_image_util/src/nodelets/blend_images_nodelet.cpp
+++ b/swri_image_util/src/nodelets/blend_images_nodelet.cpp
@@ -185,10 +185,6 @@ namespace swri_image_util
   }
 }
 
-// Reigster nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    blend_images,
-    swri_image_util::BlendImagesNodelet,
-    nodelet::Nodelet)
+// Register nodelet plugin
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, BlendImagesNodelet)

--- a/swri_image_util/src/nodelets/contrast_stretch_nodelet.cpp
+++ b/swri_image_util/src/nodelets/contrast_stretch_nodelet.cpp
@@ -137,9 +137,5 @@ namespace swri_image_util
 }
 
 // Register nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    contrast_stretch,
-    swri_image_util::ContrastStretchNodelet,
-    nodelet::Nodelet)
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, ContrastStretchNodelet)

--- a/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
+++ b/swri_image_util/src/nodelets/crosshairs_nodelet.cpp
@@ -89,4 +89,4 @@ namespace swri_image_util
 
 // Register nodelet plugin
 #include <swri_nodelet/class_list_macros.h>
-SWRI_NODELET_EXPORT_CLASS(swri_image_util, CrosshairsNodelet);
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, CrosshairsNodelet)

--- a/swri_image_util/src/nodelets/draw_text_nodelet.cpp
+++ b/swri_image_util/src/nodelets/draw_text_nodelet.cpp
@@ -103,9 +103,5 @@ namespace swri_image_util
 }
 
 // Register nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    draw_text,
-    swri_image_util::DrawTextNodelet,
-    nodelet::Nodelet)
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, DrawTextNodelet)

--- a/swri_image_util/src/nodelets/image_pub_nodelet.cpp
+++ b/swri_image_util/src/nodelets/image_pub_nodelet.cpp
@@ -112,5 +112,6 @@ namespace swri_image_util
   };
 }
 
+// Register nodelet plugin
 #include <swri_nodelet/class_list_macros.h>
-SWRI_NODELET_EXPORT_CLASS(swri_image_util, ImagePubNodelet);
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, ImagePubNodelet)

--- a/swri_image_util/src/nodelets/normalize_response_nodelet.cpp
+++ b/swri_image_util/src/nodelets/normalize_response_nodelet.cpp
@@ -104,9 +104,5 @@ namespace swri_image_util
 }
 
 // Register nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    normalize_response,
-    swri_image_util::NormalizeResponseNodelet,
-    nodelet::Nodelet)
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, NormalizeResponseNodelet)

--- a/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
+++ b/swri_image_util/src/nodelets/replace_colors_nodelet.cpp
@@ -563,9 +563,6 @@ namespace swri_image_util
   }
 }
 
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-  swri_image_util,
-  replace_colors,
-  swri_image_util::ReplaceColorsNodelet,
-  nodelet::Nodelet)
+// Register nodelet plugin
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, ReplaceColorsNodelet)

--- a/swri_image_util/src/nodelets/rotate_image_nodelet.cpp
+++ b/swri_image_util/src/nodelets/rotate_image_nodelet.cpp
@@ -103,9 +103,5 @@ namespace swri_image_util
 }
 
 // Register nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    rotate_image,
-    swri_image_util::RotateImageNodelet,
-    nodelet::Nodelet)
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, RotateImageNodelet)

--- a/swri_image_util/src/nodelets/scale_image_nodelet.cpp
+++ b/swri_image_util/src/nodelets/scale_image_nodelet.cpp
@@ -99,9 +99,5 @@ namespace swri_image_util
 }
 
 // Register nodelet plugin
-#include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS(
-    swri_image_util,
-    scale_image,
-    swri_image_util::ScaleImageNodelet,
-    nodelet::Nodelet)
+#include <swri_nodelet/class_list_macros.h>
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, ScaleImageNodelet)

--- a/swri_image_util/src/nodelets/warp_image_nodelet.cpp
+++ b/swri_image_util/src/nodelets/warp_image_nodelet.cpp
@@ -109,5 +109,6 @@ namespace swri_image_util
   };
 }
 
+// Register nodelet plugin
 #include <swri_nodelet/class_list_macros.h>
-SWRI_NODELET_EXPORT_CLASS(swri_image_util, WarpImageNodelet);
+SWRI_NODELET_EXPORT_CLASS(swri_image_util, WarpImageNodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions

Note: When replacing the macros I noticed you had your own `SWRI_NODELET_EXPORT_CLASS` macro so I modified all nodelets to use it