### PR TITLE
Add new methods that expose the frame timeout.

### DIFF
--- a/swri_transform_util/include/swri_transform_util/transform_manager.h
+++ b/swri_transform_util/include/swri_transform_util/transform_manager.h
@@ -85,6 +85,9 @@ namespace swri_transform_util
      * The frame IDs for target_frame and source_frame can be either a frame id
      * in the current TF tree or one of the special frames /UTM or /WGS84.
      *
+     * This method waits for a 0.1 second timeout if the transform is not
+     * immediately available.
+     *
      * @param[in] target_frame The TF (or special) frame id of the target
      * @param[in] source_frame The TF (or special) frame id of the source
      * @param[in] time         The requested time to request the transform.
@@ -109,6 +112,9 @@ namespace swri_transform_util
      *
      * The frame IDs for target_frame and source_frame can be either a frame id
      * in the current TF tree or one of the special frames /UTM or /WGS84.
+     *
+     * This method waits for a 0.1 second timeout if the transform is not
+     * immediately available.
      *
      * @param[in] target_frame The TF (or special) frame id of the target
      * @param[in] source_frame The TF (or special) frame id of the source
@@ -143,6 +149,9 @@ namespace swri_transform_util
      * This function is a thin wrapper around the tf::TransformListener. Only
      * TF frames are supported.
      *
+     * This method waits for a 0.1 second timeout if the transform is not
+     * immediately available.
+     *
      * @param[in] target_frame The TF frame id of the target
      * @param[in] source_frame The TF frame id of the source
      * @param[in] time         The requested time to request the transform.
@@ -165,6 +174,9 @@ namespace swri_transform_util
      * This function is a thin wrapper around the tf::TransformListener. Only
      * TF frames are supported.
      *
+     * This method waits for a 0.1 second timeout if the transform is not
+     * immediately available.
+     *
      * @param[in] target_frame The TF frame id of the target
      * @param[in] source_frame The TF frame id of the source
      * @param[out] transform   The transform requested. If the function returns
@@ -174,6 +186,57 @@ namespace swri_transform_util
     bool GetTransform(
         const std::string& target_frame,
         const std::string& source_frame,
+        tf::StampedTransform& transform) const;
+
+    /**
+     * Get the tf::Transform between two frames at a specified time
+     *
+     * This function is a thin wrapper around the tf::TransformListener. Only
+     * TF frames are supported.
+     *
+     * If the frames are not immediately available, this method will wait
+     * for the frames for the specified timeout period.
+     *
+     * @param[in] target_frame The TF frame id of the target
+     * @param[in] source_frame The TF frame id of the source
+     * @param[in] time         The requested time to request the transform.
+     *    ros::Time(0) means the most recent time for which a valid transform
+     *    is available.
+     * @param[in] timeout      How long to wait for the transform to be
+     *    available before returning False.
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated.
+     * @return True if the transform is available at the requested time. False
+     *    otherwise.
+     */
+    bool GetTransform(
+        const std::string& target_frame,
+        const std::string& source_frame,
+        const ros::Time& time,
+        const ros::Duration& timeout,
+        tf::StampedTransform& transform) const;
+
+    /**
+     * Get the most recent tf::Transform between two frames
+     *
+     * This function is a thin wrapper around the tf::TransformListener. Only
+     * TF frames are supported.
+     *
+     * If the frames are not immediately available, this method will wait
+     * for the frames for the specified timeout period.
+     *
+     * @param[in] target_frame The TF frame id of the target
+     * @param[in] source_frame The TF frame id of the source
+     * @param[in] timeout      How long to wait for the transform to be
+     *    available before returning False.
+     * @param[out] transform   The transform requested. If the function returns
+     *    false, transform is not mutated.
+     * @return True if the transform is available. False otherwise.
+     */
+    bool GetTransform(
+        const std::string& target_frame,
+        const std::string& source_frame,
+        const ros::Duration& timeout,
         tf::StampedTransform& transform) const;
 
   private:

--- a/swri_transform_util/src/transform_manager.cpp
+++ b/swri_transform_util/src/transform_manager.cpp
@@ -349,6 +349,16 @@ namespace swri_transform_util
       const ros::Time& time,
       tf::StampedTransform& transform) const
   {
+    return GetTransform(target_frame, source_frame, time, ros::Duration(0.1), transform);
+  }
+
+  bool TransformManager::GetTransform(
+      const std::string& target_frame,
+      const std::string& source_frame,
+      const ros::Time& time,
+      const ros::Duration& timeout,
+      tf::StampedTransform& transform) const
+  {
     if (!tf_listener_)
       return false;
 
@@ -359,7 +369,7 @@ namespace swri_transform_util
           target_frame,
           source_frame,
           time,
-          ros::Duration(0.1));
+          timeout);
 
       tf_listener_->lookupTransform(
           target_frame,
@@ -395,5 +405,14 @@ namespace swri_transform_util
       tf::StampedTransform& transform) const
   {
     return GetTransform(target_frame, source_frame, ros::Time(0), transform);
+  }
+
+  bool TransformManager::GetTransform(
+      const std::string& target_frame,
+      const std::string& source_frame,
+      const ros::Duration& timeout,
+      tf::StampedTransform& transform) const
+  {
+    return GetTransform(target_frame, source_frame, ros::Time(0), timeout, transform);
   }
 }


### PR DESCRIPTION
Add two new GetTransform methods to TransformManager that expose the
wait duration for frames to be available for tf::TransformListener frames.

Replace existing GetTransform method with a wrapper around the new method
that calls it with Duration(0.1) to replicate the current behavior and avoid
ABI breakage.

Update doxygen documentation accordingly.