### PR TITLE
expose the local_xy_util_

### DIFF
--- a/swri_transform_util/include/swri_transform_util/local_xy_util.h
+++ b/swri_transform_util/include/swri_transform_util/local_xy_util.h
@@ -136,6 +136,12 @@ namespace swri_transform_util
     bool Initialized() const { return initialized_; }
 
     /**
+     * Reset to "not Initialized". Useful when the local_xy_origin
+     * changes and we want this class to be updated.
+     */
+    void ResetInitialization();
+
+    /**
      * Return the longitude coordinate of the local origin
      *
      * @return The WGS84 longitude coordinate of the local origin in degrees

--- a/swri_transform_util/include/swri_transform_util/transform_manager.h
+++ b/swri_transform_util/include/swri_transform_util/transform_manager.h
@@ -239,13 +239,20 @@ namespace swri_transform_util
         const ros::Duration& timeout,
         tf::StampedTransform& transform) const;
 
+    /**
+     * @brief LocalXyUtil exposes the private instance of LocalXyWgs84Util
+     * @return
+     */
+    const LocalXyWgs84UtilPtr& LocalXyUtil() const;
+
   private:
     boost::shared_ptr<tf::TransformListener> tf_listener_;
 
-    boost::shared_ptr<LocalXyWgs84Util> local_xy_util_;
+    LocalXyWgs84UtilPtr local_xy_util_;
 
     SourceTargetMap transformers_;
   };
+  typedef boost::shared_ptr<TransformManager> TransformManagerPtr;
 }
 
 #endif  // TRANSFORM_UTIL_TRANSFORM_MANAGER_H_

--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -107,6 +107,16 @@ namespace swri_transform_util
     origin_sub_ = node.subscribe("/local_xy_origin", 1, &LocalXyWgs84Util::HandleOrigin, this);
   }
 
+  void LocalXyWgs84Util::ResetInitialization()
+  {
+    if( initialized_ )
+    {
+      ros::NodeHandle node;
+      origin_sub_ = node.subscribe("/local_xy_origin", 1, &LocalXyWgs84Util::HandleOrigin, this);
+      initialized_ = false;
+    }
+  }
+
   void LocalXyWgs84Util::Initialize()
   {
     reference_angle_ = swri_math_util::WrapRadians(reference_angle_, 0);

--- a/swri_transform_util/src/transform_manager.cpp
+++ b/swri_transform_util/src/transform_manager.cpp
@@ -363,4 +363,9 @@ namespace swri_transform_util
   {
     return GetTransform(target_frame, source_frame, ros::Time(0), timeout, transform);
   }
+
+  const LocalXyWgs84UtilPtr &TransformManager::LocalXyUtil() const
+  {
+    return local_xy_util_;
+  }
 }


### PR DESCRIPTION
Hi.

exposing the shared_ptr of local_xy_util_,  plugins in mapviz can use it instead of creating their own instance.

