### PR TITLE
Use pkgconfig to include libproj in swri_transform_util

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,15 +20,14 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
-if($ENV{ROS_DISTRO} STRLESS "kinetic")
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROJ proj)
+if(NOT "${PROJ_FOUND}")
   set(PROJ_INCLUDE_DIRS /usr/include)
   set(PROJ_LIBRARY_DIRS /usr/lib)
   find_library(PROJ_LIBRARIES proj
     HINTS ${PROJ_LIB_DIRS}
   )
-else()
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(PROJ REQUIRED proj)
 endif()
 
 generate_dynamic_reconfigure_options(

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
-if($ENV{ROS_DISTRO} STREQUAL "jade")
+if($ENV{ROS_DISTRO} STRLESS "kinetic")
   set(PROJ_INCLUDE_DIRS /usr/include)
   set(PROJ_LIBRARY_DIRS /usr/lib)
   find_library(PROJ_LIBRARIES proj

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
-if($ENV{ROS_DISTRO} STREQUAL "indigo")
+if($ENV{ROS_DISTRO} STREQUAL "jade")
   set(PROJ_INCLUDE_DIRS /usr/include)
   set(PROJ_LIBRARY_DIRS /usr/lib)
   find_library(PROJ_LIBRARIES proj

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,6 +20,9 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PROJ REQUIRED proj)
+
 generate_dynamic_reconfigure_options(
   cfg/DynamicPublisher.cfg
 )
@@ -41,12 +44,14 @@ catkin_package(
     swri_yaml_util
     tf
     topic_tools
+  DEPENDS PROJ
 )
 
 include_directories(include 
   ${catkin_INCLUDE_DIRS} 
   ${Boost_INCLUDE_DIRS} 
   ${OpenCV_INCLUDE_DIRS}
+  ${PROJ_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}
@@ -60,7 +65,7 @@ add_library(${PROJECT_NAME}
   src/utm_transformer.cpp
   src/wgs84_transformer.cpp)
 link_directories(${OpenCV_LIBRARY_DIRS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBS} proj)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OpenCV_LIBS} ${PROJ_LIBRARIES})
 
 add_library(${PROJECT_NAME}_nodelets
   src/nodelets/dynamic_publisher.cpp)

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,8 +20,16 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV  REQUIRED core highgui imgproc video)
 find_package(Boost REQUIRED)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PROJ REQUIRED proj)
+if($ENV{ROS_DISTRO} STREQUAL "indigo")
+  set(PROJ_INCLUDE_DIRS /usr/include)
+  set(PROJ_LIBRARY_DIRS /usr/lib)
+  find_library(PROJ_LIBRARIES proj
+    HINTS ${PROJ_LIB_DIRS}
+  )
+else()
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(PROJ REQUIRED proj)
+endif()
 
 generate_dynamic_reconfigure_options(
   cfg/DynamicPublisher.cfg

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -13,6 +13,7 @@
   <url>https://github.com/swri-robotics/marti_common</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>boost</depend>
   <depend>cv_bridge</depend>


### PR DESCRIPTION
Previously the CMakeLists.txt simply appended "proj" to the library
list, which happened to work, but is not actually the correct way to
include libraries that provide a .pc file; that could potentially fail
on any systems that don't have libproj in their default include path.

Discovered by @matt-attack.