### PR TITLE
Ensure all swri::Subscriber members are initialized

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -75,8 +75,7 @@ class SubscriberImpl
       min_latency_ = latency;
       max_latency_ = latency;
       total_latency_ = latency;
-    }
-    else {
+    } else {
       min_latency_ = std::min(min_latency_, latency);
       max_latency_ = std::max(max_latency_, latency);
       total_latency_ += latency;
@@ -88,8 +87,7 @@ class SubscriberImpl
         min_period_ = period;
         max_period_ = period;
         total_periods_ = period;
-      }
-      else if (message_count_ > 2) {
+      } else if (message_count_ > 2) {
         min_period_ = std::min(min_period_, period);
         max_period_ = std::max(max_period_, period);
         total_periods_ += period;

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -70,15 +70,17 @@ class SubscriberImpl
 
     message_count_++;
 
-    ros::Duration latency = now - stamp;
-    if (message_count_ == 1) {
-      min_latency_ = latency;
-      max_latency_ = latency;
-      total_latency_ = latency;
-    } else {
-      min_latency_ = std::min(min_latency_, latency);
-      max_latency_ = std::max(max_latency_, latency);
-      total_latency_ += latency;
+    if (stamp.isValid()) {
+      ros::Duration latency = now - stamp;
+      if (message_count_ == 1) {
+        min_latency_ = latency;
+        max_latency_ = latency;
+        total_latency_ = latency;
+      } else {
+        min_latency_ = std::min(min_latency_, latency);
+        max_latency_ = std::max(max_latency_, latency);
+        total_latency_ += latency;
+      }
     }
 
     if (message_count_ > 1) {
@@ -166,8 +168,12 @@ class SubscriberImpl
   {
     if (message_count_ < 1) {
       return ros::DURATION_MAX;
-    } else {
+    } else if (last_header_stamp_.isValid()) {
       return now - last_header_stamp_;
+    } else {
+      // If we've received messages but they don't have valid stamps, we can't
+      // actually determine the age, so just return an empty duration.
+      return ros::Duration(0.0);
     }
   }
 

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -75,7 +75,8 @@ class SubscriberImpl
       min_latency_ = latency;
       max_latency_ = latency;
       total_latency_ = latency;
-    } else {
+    }
+    else {
       min_latency_ = std::min(min_latency_, latency);
       max_latency_ = std::max(max_latency_, latency);
       total_latency_ += latency;
@@ -87,7 +88,8 @@ class SubscriberImpl
         min_period_ = period;
         max_period_ = period;
         total_periods_ = period;
-      } else if (message_count_ > 2) {
+      }
+      else if (message_count_ > 2) {
         min_period_ = std::min(min_period_, period);
         max_period_ = std::max(max_period_, period);
         total_periods_ += period;
@@ -123,12 +125,15 @@ class SubscriberImpl
 
 
  public:
-  SubscriberImpl()
+  SubscriberImpl() :
+    unmapped_topic_("N/A"),
+    mapped_topic_("N/A"),
+    message_count_(0),
+    timeout_(-1.0),
+    in_timeout_(false),
+    timeout_count_(0),
+    blocking_timeout_(false)
   {
-    unmapped_topic_ = "N/A";
-    mapped_topic_ = "N/A";
-    timeout_ = ros::Duration(-1.0);
-    blocking_timeout_ = false;
     resetStatistics();
   }
 


### PR DESCRIPTION
Some member variables in swri::Subscriber were uninitialized by default; this ensures all of them are initialized.