### PR TITLE
Support ROS Melodic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ jobs:
   include:
     - stage: build-shadow-fixed
       env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
     - stage: build-released
       env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - stage: lint
       sudo: false
       install: pip install --user -q catkin-lint
@@ -29,7 +29,7 @@ jobs:
       env: JOB="catkin_lint"
   allow_failures:
     - env: ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: JOB="catkin_lint"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ marti\_common [![Build Status](https://travis-ci.org/swri-robotics/marti_common.
 
 This repository provides various utility packages created at [Southwest Reseach Institute](http://www.swri.org)'s [Intelligent Vehicle Systems](http://www.swri.org/4org/d10/isd/ivs/default.htm) section for working with [Robot Operating System(ROS)](http://www.ros.org).
 
-Installation (ROS Indigo, Jade, Kinetic, Lunar)
+Installation (ROS Indigo, Kinetic, Lunar, Melodic)
 -------------
 
-If you have installed ROS Indigo, Jade, Kinetic, or Lunar, you can install any of the packages in this repository with apt-get:
+If you have installed ROS Indigo, Kinetic, Lunar, or Melodic, you can install any of the packages in this repository with apt-get:
 
     sudo apt-get install ros-${ROS_DISTRO}-<package>
 
-Building From Source (ROS Indigo, Jade, Kinetic, Lunar)
+Building From Source (ROS Indigo, Kinetic, Lunar, Melodic)
 ------------
 
 These directions assume you have already set up a catkin workspace and rosdep. See [this tutorial](http://wiki.ros.org/catkin/Tutorials/create_a_workspace) on the ROS Wiki for help setting up a catkin workspace and the [rosdep documentation](http://wiki.ros.org/rosdep) on the ROS wiki for help setting up rosdep.

--- a/swri_opencv_util/src/show.cpp
+++ b/swri_opencv_util/src/show.cpp
@@ -64,7 +64,11 @@ namespace swri_opencv_util
       }
     }
 
+#if (BOOST_VERSION / 100 % 1000) >= 65
+    friend class boost::serialization::singleton<CvWindows>;
+#else
     friend class boost::serialization::detail::singleton_wrapper<CvWindows>;
+#endif
   private:
     CvWindows() {}
     boost::mutex mutex_;

--- a/swri_transform_util/include/swri_transform_util/utm_util.h
+++ b/swri_transform_util/include/swri_transform_util/utm_util.h
@@ -158,7 +158,11 @@ namespace swri_transform_util
           int zone, char band, double easting, double northing,
           double& latitude, double& longitude) const;
 
+#if (BOOST_VERSION / 100 % 1000) >= 65
+        friend class boost::serialization::singleton<swri_transform_util::UtmUtil::UtmData>;
+#else
         friend class boost::serialization::detail::singleton_wrapper<swri_transform_util::UtmUtil::UtmData>;
+#endif
       private:
         UtmData();
 


### PR DESCRIPTION
Ubuntu 18.04 comes with boost 1.65.1, and the usage of the `boost::serialization::singleton` class changed slightly in it (see https://www.boost.org/doc/libs/1_65_0/libs/serialization/doc/singleton.html ).  This will make marti_common compile properly on 18.04 / Melodic.