### PR TITLE
Only calculate statistics when messages arrive in order

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -69,7 +69,7 @@ class SubscriberImpl
     checkTimeout(now);
 
     // Do not use this message for statistics if it is arriving out of order
-    if (stamp > last_header_stamp_) {
+    if (stamp >= last_header_stamp_) {
       message_count_++;
 
       if (!stamp.isZero()) {

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -68,34 +68,36 @@ class SubscriberImpl
     // timeout count.
     checkTimeout(now);
 
-    message_count_++;
+    // Do not use this message for statistics if it is arriving out of order
+    if (stamp > last_header_stamp_) {
+      message_count_++;
 
-    if (!stamp.isZero()) {
-      ros::Duration latency = now - stamp;
-      if (message_count_ == 1) {
-        min_latency_ = latency;
-        max_latency_ = latency;
-        total_latency_ = latency;
-      } else {
-        min_latency_ = std::min(min_latency_, latency);
-        max_latency_ = std::max(max_latency_, latency);
-        total_latency_ += latency;
+      if (!stamp.isZero()) {
+        ros::Duration latency = now - stamp;
+        if (message_count_ == 1) {
+          min_latency_ = latency;
+          max_latency_ = latency;
+          total_latency_ = latency;
+        } else {
+          min_latency_ = std::min(min_latency_, latency);
+          max_latency_ = std::max(max_latency_, latency);
+          total_latency_ += latency;
+        }
+      }
+
+      if (message_count_ > 1) {
+        ros::Duration period = now - last_receive_time_;
+        if (message_count_ == 2) {
+          min_period_ = period;
+          max_period_ = period;
+          total_periods_ = period;
+        } else if (message_count_ > 2) {
+          min_period_ = std::min(min_period_, period);
+          max_period_ = std::max(max_period_, period);
+          total_periods_ += period;
+        }
       }
     }
-
-    if (message_count_ > 1) {
-      ros::Duration period = now - last_receive_time_;
-      if (message_count_ == 2) {
-        min_period_ = period;
-        max_period_ = period;
-        total_periods_ = period;
-      } else if (message_count_ > 2) {
-        min_period_ = std::min(min_period_, period);
-        max_period_ = std::max(max_period_, period);
-        total_periods_ += period;
-      }
-    }
-
     // Reset the timeout condition to false.
     in_timeout_ = false;
 


### PR DESCRIPTION
I have a bag file where the messages are not recorded in order. This causes a problem when playing it back through a SwRI subscriber, because the statistics calculated in the subscriber generate negative durations, which causes ROS to throw and exception. This fix only calculates statistics when messages are arriving in order, which makes the system more robust to problematic data.