### PR TITLE
Handle invalid fixes properly

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -108,6 +108,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
   target_link_libraries(test_transform_util ${PROJECT_NAME})
 
+  add_rostest(test/initialize_invalid_gps.test)
+  add_rostest(test/initialize_invalid_navsat.test)
   add_rostest(test/initialize_origin_auto_gps.test)
   add_rostest(test/initialize_origin_auto_navsat.test)
   add_rostest(test/initialize_origin_manual.test)

--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -37,25 +37,23 @@ from swri_transform_util.origin_manager import OriginManager, InvalidFixExceptio
 def navsat_callback(msg, (manager, navsat_sub, gps_sub)):
         try:
             manager.set_origin_from_navsat(msg)
-        except InvalidFixException as e:
-            rospy.logwarn(e)
-            return
-        finally:
             rospy.loginfo('Got NavSat message. Setting origin and unsubscribing from NavSat.')
             navsat_sub.unregister()
             gps_sub.unregister()
+        except InvalidFixException as e:
+            rospy.logwarn(e)
+            return
 
 
 def gps_callback(msg, (manager, gps_sub, navsat_sub)):
         try:
             manager.set_origin_from_gps(msg)
-        except InvalidFixException as e:
-            rospy.logwarn(e)
-            return
-        finally:
             rospy.loginfo('Got GPSFix message. Setting origin and unsubscribing from GPSFix.')
             gps_sub.unregister()
             navsat_sub.unregister()
+        except InvalidFixException as e:
+            rospy.logwarn(e)
+            return
 
 
 rospy.init_node('initialize_origin', anonymous=True)

--- a/swri_transform_util/test/initialize_invalid_gps.test
+++ b/swri_transform_util/test/initialize_invalid_gps.test
@@ -4,8 +4,8 @@
       <param name="local_xy_frame" value="/far_field"/>
   </node>
   <test
-      test-name="test_initialize_origin_auto_navsat"
+      test-name="test_invalid_gps"
       pkg="swri_transform_util"
       type="test_initialize_origin.py"
-      args="auto_navsat" />
+      args="invalid_gps" />
 </launch>

--- a/swri_transform_util/test/initialize_invalid_navsat.test
+++ b/swri_transform_util/test/initialize_invalid_navsat.test
@@ -4,8 +4,8 @@
       <param name="local_xy_frame" value="/far_field"/>
   </node>
   <test
-      test-name="test_initialize_origin_auto_navsat"
+      test-name="test_invalid_navsat"
       pkg="swri_transform_util"
       type="test_initialize_origin.py"
-      args="auto_navsat" />
+      args="invalid_navsat" />
 </launch>

--- a/swri_transform_util/test/initialize_origin_auto_gps.test
+++ b/swri_transform_util/test/initialize_origin_auto_gps.test
@@ -4,7 +4,7 @@
       <param name="local_xy_frame" value="/far_field"/>
   </node>
   <test
-      test-name="test_initialize_origin"
+      test-name="test_initialize_origin_auto_gps"
       pkg="swri_transform_util"
       type="test_initialize_origin.py"
       args="auto_gps" />


### PR DESCRIPTION
If initialize_origin.py got an invalid fix, it would unsubscribe from
the fix/gps topics but not publish a /local_xy_origin, thus leaving the
system eternally stranded.  Now it will continue to listen until a valid
fix arrives.

Fixes #518 