### PR TITLE
Support in initialize_origin.py specifying custom ROS topic in parameter

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -103,6 +103,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/initialize_invalid_gps.test)
   add_rostest(test/initialize_invalid_navsat.test)
+  add_rostest(test/initialize_origin_auto_custom.test)
   add_rostest(test/initialize_origin_auto_gps.test)
   add_rostest(test/initialize_origin_auto_navsat.test)
   add_rostest(test/initialize_origin_manual.test)

--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -28,58 +28,113 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from importlib import import_module
+
 from gps_common.msg import GPSFix
 import rospy
 from sensor_msgs.msg import NavSatFix
 from swri_transform_util.origin_manager import OriginManager, InvalidFixException
 
 
-def navsat_callback(msg, (manager, navsat_sub, gps_sub)):
-        try:
-            manager.set_origin_from_navsat(msg)
-            rospy.loginfo('Got NavSat message. Setting origin and unsubscribing from NavSat.')
-            navsat_sub.unregister()
-            gps_sub.unregister()
-        except InvalidFixException as e:
-            rospy.logwarn(e)
-            return
-
-
-def gps_callback(msg, (manager, gps_sub, navsat_sub)):
-        try:
-            manager.set_origin_from_gps(msg)
-            rospy.loginfo('Got GPSFix message. Setting origin and unsubscribing from GPSFix.')
-            gps_sub.unregister()
-            navsat_sub.unregister()
-        except InvalidFixException as e:
-            rospy.logwarn(e)
-            return
-
-
-rospy.init_node('initialize_origin', anonymous=True)
-local_xy_frame = rospy.get_param('~local_xy_frame', 'map')
-local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
-manager = OriginManager(local_xy_frame)
-if local_xy_origin == 'auto':
-    gps_sub = rospy.Subscriber('gps', GPSFix, queue_size=2)
-    navsat_sub = rospy.Subscriber('fix', NavSatFix, queue_size=2)
-    gps_sub.impl.add_callback(gps_callback,
-                              (manager, gps_sub, navsat_sub))  # Extra arguments to callback
-    navsat_sub.impl.add_callback(navsat_callback,
-                                 (manager, navsat_sub, gps_sub))  # Extra arguments to callback
-else:
+def navsat_callback(msg, params):
+    (manager, subscribers) = params
     try:
-        origin_list = rospy.get_param('~local_xy_origins')
-    except KeyError:
-        message = 'local_xy_frame is "{}", but local_xy_origins is not specified'
-        rospy.logfatal(message.format(local_xy_frame))
-        exit(1)
+        subs = list(subscribers)
+        while subscribers: subscribers.pop()
+        rospy.loginfo('Got NavSat message. Setting origin and unsubscribing.')
+        manager.set_origin_from_navsat(msg)
+        for sub in subs:
+            sub.unregister()
+    except InvalidFixException as e:
+        rospy.logwarn(e)
+        return
+
+
+def gps_callback(msg, params):
+    (manager, subscribers) = params
     try:
-        manager.set_origin_from_list(local_xy_origin, origin_list)
-    except (TypeError, KeyError) as e:
-        message = 'local_xy_origins is malformed or does not contain the local_xy_frame "{}"'
-        rospy.logfatal(message.format(local_xy_frame))
-        rospy.logfatal(e)
-        exit(1)
-manager.start()
-rospy.spin()
+        subs = list(subscribers)
+        while subscribers: subscribers.pop()
+        rospy.loginfo('Got GPSFix message. Setting origin and unsubscribing.')
+        manager.set_origin_from_gps(msg)
+        for sub in subs:
+            sub.unregister()
+    except InvalidFixException as e:
+        rospy.logwarn(e)
+        return
+
+
+def custom_callback(self, params):
+    (manager, subscribers) = params
+    connection_header = self._connection_header['type'].split('/')
+    ros_pkg = connection_header[0] + '.msg'
+    msg_type = connection_header[1]
+    msg_class = getattr(import_module(ros_pkg), msg_type)
+    msg = msg_class().deserialize(self._buff)
+    stamp = None
+    if hasattr(msg, 'header') and hasattr(msg.header, 'stamp'):
+        stamp = msg.header.stamp
+    if hasattr(msg, 'pose'): # Messages like GeoPoseStamped
+        msg = msg.pose
+    if hasattr(msg, 'position'): # Messages like GeoPose
+        msg = msg.position
+    pos = None
+    if hasattr(msg, 'latitude') and hasattr(msg, 'longitude') and hasattr(msg, 'altitude'):
+        pos = (msg.latitude, msg.longitude, msg.altitude)
+    elif hasattr(msg, 'lat') and hasattr(msg, 'lon') and hasattr(msg, 'height'):
+        pos = (msg.lat, msg.lon, msg.height)
+
+    if pos:
+        subs = list(subscribers)
+        while subscribers: subscribers.pop()
+        rospy.loginfo('Got {} message from topic "{}". Setting origin and unsubscribing.'
+                      .format(self._connection_header['type'], self._connection_header['topic']))
+        manager.set_origin_from_custom(pos, stamp)
+        for sub in subs:
+            sub.unregister()
+
+
+def main():
+    rospy.init_node('initialize_origin', anonymous=True)
+    local_xy_frame = rospy.get_param('~local_xy_frame', 'map')
+    local_xy_origin = rospy.get_param('~local_xy_origin', 'auto')
+    manager = OriginManager(local_xy_frame)
+    if local_xy_origin == 'auto':
+        local_xy_gpsfix_topic = rospy.get_param('~local_xy_gpsfix_topic', 'gps')
+        gps_sub = rospy.Subscriber(local_xy_gpsfix_topic, GPSFix, queue_size=2)
+        local_xy_navsatfix_topic = rospy.get_param('~local_xy_navsatfix_topic', 'fix')
+        navsat_sub = rospy.Subscriber(local_xy_navsatfix_topic, NavSatFix, queue_size=2)
+        subscribers = [gps_sub, navsat_sub]
+        local_xy_custom_topic = rospy.get_param('~local_xy_custom_topic', None)
+        if local_xy_custom_topic:
+            custom_sub = rospy.Subscriber(local_xy_custom_topic, rospy.AnyMsg, queue_size=2)
+            subscribers.append(custom_sub)
+
+        # Add extra arguments to callback
+        gps_sub.impl.add_callback(
+            gps_callback, (manager, subscribers))
+        navsat_sub.impl.add_callback(
+            navsat_callback, (manager, subscribers))
+        if local_xy_custom_topic:
+            custom_sub.impl.add_callback(
+                custom_callback, (manager, subscribers))
+    else:
+        try:
+            origin_list = rospy.get_param('~local_xy_origins')
+        except KeyError:
+            message = 'local_xy_origin is "{}", but local_xy_origins is not specified'
+            rospy.logfatal(message.format(local_xy_origin))
+            exit(1)
+        try:
+            manager.set_origin_from_list(local_xy_origin, origin_list)
+        except (TypeError, KeyError) as e:
+            message = 'local_xy_origins is malformed or does not contain the local_xy_origin "{}"'
+            rospy.logfatal(message.format(local_xy_origin))
+            rospy.logfatal(e)
+            exit(1)
+    manager.start()
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()

--- a/swri_transform_util/test/initialize_origin_auto_custom.test
+++ b/swri_transform_util/test/initialize_origin_auto_custom.test
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="origin" pkg="swri_transform_util" type="initialize_origin.py">
+      <param name="local_xy_frame" value="/far_field"/>
+      <param name="local_xy_custom_topic" value="pose"/>
+  </node>
+  <test
+      test-name="test_initialize_origin_auto_custom"
+      pkg="swri_transform_util"
+      type="test_initialize_origin.py"
+      args="auto_custom" />
+</launch>


### PR DESCRIPTION
User can specify in parameter 'local_xy_custom_topic' ROS topic that will be used for origin.
Message can use fields with names 'latitude', 'longitude', 'altitude' or 'lat', 'lon' and 'height'.
These fields can also be inside the message field with name 'position'.

Also, you can specify topic for GPSFix message in parameter '~local_xy_gpsfix_topic', and
topic for NavSatFix message in parameter '~local_xy_navsatfix_topic'