### PR TITLE
Fix get relative transform

### DIFF
--- a/swri_transform_util/src/transform_util.cpp
+++ b/swri_transform_util/src/transform_util.cpp
@@ -77,7 +77,7 @@ namespace swri_transform_util
         x, y);
 
     tf::Vector3 origin =
-        tf::Transform(reference_rotation) * tf::Vector3(x, y, 0);
+        tf::Transform(reference_rotation.inverse()) * tf::Vector3(x, y, 0);
     transform.setOrigin(origin);
 
     return transform;

--- a/swri_transform_util/test/test_transform_util.cpp
+++ b/swri_transform_util/test/test_transform_util.cpp
@@ -39,7 +39,18 @@
 #include <swri_math_util/math_util.h>
 #include <swri_transform_util/transform_util.h>
 
-// TODO(malban): Add unit tests for GetRelativeTransform()
+TEST(TransformUtilTests, GetRelativeTransform)
+{
+  tf::Transform offset = swri_transform_util::GetRelativeTransform(
+                29.441679990508018, -98.602031700252184, -1.2030287,
+                29.441609529848606, -98.601997698933161, -1.21015707397341
+                );
+
+  tf::Vector3 origin = offset.getOrigin();
+  EXPECT_FLOAT_EQ(-8.47174665, origin.x());
+  EXPECT_FLOAT_EQ(-0.3306987, origin.y());
+  EXPECT_FLOAT_EQ(0.0, origin.z());
+}
 
 TEST(TransformUtilTests, GetBearing)
 {


### PR DESCRIPTION
The GetRelativeTransform function appears to have not been working. This change makes it behave as expected.