### PR TITLE
Fix dependencies for swri_image_util

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-marti\_common [![Build Status](https://travis-ci.org/swri-robotics/marti_common.svg?branch=dashing-devel)](https://travis-ci.org/swri-robotics/marti_common)
+marti\_common
+[![Travis CI Build Status](https://travis-ci.org/swri-robotics/marti_common.svg?branch=dashing-devel)](https://travis-ci.org/swri-robotics/marti_common)
+[![ROS Build Farm Build Status](http://build.ros2.org/buildStatus/icon?job=Dpr__marti_common__ubuntu_bionic_amd64)](http://build.ros2.org/job/Dpr__marti_common__ubuntu_bionic_amd64/)
 =============
 
 This repository provides various utility packages created at [Southwest Reseach Institute](http://www.swri.org)'s [Intelligent Vehicle Systems](http://www.swri.org/4org/d10/isd/ivs/default.htm) section for working with [Robot Operating System(ROS)](http://www.ros.org).  This branch adds support for ROS 2 Dashing.  Most packages from ROS 1 have been ported, but a few have been removed due to being unnecessary or redundant, and some functionality is not implemented yet.

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -34,6 +34,8 @@
   <depend>swri_roscpp</depend>
   <depend>tf2</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -77,7 +77,7 @@ class Subscriber
              uint32_t queue_size,
              void(T::*fp)(const std::shared_ptr< M const > &),
              T *obj,
-             const rmw_qos_profile_t& transport_hints = rmw_qos_profile_default);
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
 
   // Using a boost function callback.
   template<class M>
@@ -85,7 +85,7 @@ class Subscriber
              const std::string &topic,
              uint32_t queue_size,
              const std::function<void(const std::shared_ptr<M const> &)> &callback,
-             const rmw_qos_profile_t& transport_hints = rmw_qos_profile_default);
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
 
   // This is an alternate interface that stores a received message in
   // a variable without calling a user-defined callback function.
@@ -96,7 +96,7 @@ class Subscriber
   Subscriber(rclcpp::Node &nh,
              const std::string &topic,
              std::shared_ptr< M const > *dest,
-             const rmw_qos_profile_t& transport_hints = rmw_qos_profile_default);
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
   
   Subscriber& operator=(const Subscriber &other);
 
@@ -208,7 +208,7 @@ Subscriber::Subscriber(rclcpp::Node &nh,
                        uint32_t queue_size,
                        void(T::*fp)(const std::shared_ptr< M const > &),
                        T *obj,
-                       const rmw_qos_profile_t& transport_hints)
+                       const rclcpp::QoS& transport_hints)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new TypedSubscriberImpl<M,T>(
@@ -221,7 +221,7 @@ Subscriber::Subscriber(rclcpp::Node &nh,
                        const std::string &topic,
                        uint32_t queue_size,
                        const std::function<void(const std::shared_ptr<M const> &)> &callback,
-                       const rmw_qos_profile_t& transport_hints)
+                       const rclcpp::QoS& transport_hints)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new BindSubscriberImpl<M>(
@@ -233,7 +233,7 @@ inline
 Subscriber::Subscriber(rclcpp::Node &nh,
                        const std::string &topic,
                        std::shared_ptr< M const > *dest,
-                       const rmw_qos_profile_t& transport_hints)
+                       const rclcpp::QoS& transport_hints)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new StorageSubscriberImpl<M>(

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -308,7 +308,7 @@ namespace swri
         uint32_t queue_size,
         void(T::*fp)(const std::shared_ptr< M const > &),
         T *obj,
-        const rmw_qos_profile_t& transport_hints)
+        const rclcpp::QoS& transport_hints)
     {
       unmapped_topic_ = topic;
       // mapped_topic_ = nh->ResolveName(topic);
@@ -321,13 +321,14 @@ namespace swri
       obj_ = obj;
       //transport_hints.depth = queue_size;
 
-      rmw_qos_profile_t hints = transport_hints;
-      hints.depth = queue_size;
+      rclcpp::QoS hints = transport_hints;
+      hints.keep_last(queue_size);
 
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
+                                         hints,
                                          std::bind(&TypedSubscriberImpl::handleMessage<M>,
-                                                   this, std::placeholders::_1),
-                                         hints);
+                                                   this, std::placeholders::_1)
+                                         );
     }
 
     // Handler for messages with headers
@@ -361,7 +362,7 @@ namespace swri
         const std::string &topic,
         uint32_t queue_size,
         const std::function<void(const std::shared_ptr< const M > )> &callback,
-        const rmw_qos_profile_t& transport_hints)
+        const rclcpp::QoS& transport_hints)
     {
       unmapped_topic_ = topic;
       //mapped_topic_ = nh->ResolveName(topic);
@@ -371,12 +372,13 @@ namespace swri
 
       callback_ = callback;
 
-      rmw_qos_profile_t hints = transport_hints;
-      hints.depth = queue_size;
+      rclcpp::QoS hints = transport_hints;
+      hints.keep_last(queue_size);
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
-                                      std::bind(&BindSubscriberImpl::handleMessage<M>,
-                                                this, std::placeholders::_1),
-                                      hints);
+                                         hints,
+                                         std::bind(&BindSubscriberImpl::handleMessage<M>,
+                                                   this, std::placeholders::_1)
+                                        );
     }
 
     // Handler for messages with headers
@@ -408,7 +410,7 @@ namespace swri
         rclcpp::Node& nh,
         const std::string &topic,
         std::shared_ptr< const M > *dest,
-        const rmw_qos_profile_t& transport_hints)
+        const rclcpp::QoS& transport_hints)
     {
       unmapped_topic_ = topic;
       //mapped_topic_ = nh->ResolveName(topic);
@@ -418,9 +420,10 @@ namespace swri
 
       dest_ = dest;
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
+                                         transport_hints,
                                          std::bind(&StorageSubscriberImpl::handleMessage<M>,
-                                                   this, std::placeholders::_1),
-                                         transport_hints);
+                                                   this, std::placeholders::_1)
+                                         );
     }
 
     // Handler for messages with headers


### PR DESCRIPTION
It needed to have ament_cmake_gtest added to it.

Distribution Statement A; OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>