### PR TITLE
Refactor Topic Service Generation

### DIFF
--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
@@ -29,36 +29,21 @@ macro(add_topic_service_files)
     string(REPLACE ".srv" "" current_ResOut ${current_ResOut})
 
     file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg)
+    file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/)
 
-    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/topic_srv/${_file} _fileContents)
-    
-    string(REPLACE "---" ";" CONTENTS_LIST ${_fileContents})
-   
-    #include(${CMAKE_CURRENT_SOURCE_DIR}/topic_srv/${_file})
-
-    list(GET CONTENTS_LIST 0 MSG_REQUEST)
-    list(GET CONTENTS_LIST 1 MSG_RESPONSE)
-
-    file(WRITE ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg/${current_ReqOut} "marti_common_msgs/ServiceHeader srv_header\n" ${MSG_REQUEST})
-    file(WRITE ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg/${current_ResOut} "marti_common_msgs/ServiceHeader srv_header\n" ${MSG_RESPONSE})
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/topic_srv/${_file})
 
     set(headerName ${_file})
     string(REPLACE ".srv" ".h" headerName ${headerName})
-    add_custom_target(${_file}thing
+    safe_execute_process(
       COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${swri_roscpp_BIN}service_splitter.py ${_file} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg/${current_ReqOut} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg/${current_ResOut} ${PROJECT_NAME} ${_file} ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/${headerName}
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/topic_srv"
     )
-    add_dependencies(${catkin_EXPORTED_TARGETS}  
-         ${_file}thing)
 
     add_message_files(DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/msg FILES
       ${current_ReqOut} 
       ${current_ResOut}
     )
-
-    foreach (_proj ${catkin_EXPORTED_TARGETS})
-      add_dependencies(${_proj} ${_file}thing)
-    endforeach()
 
     # install the header
     install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/${headerName}


### PR DESCRIPTION
Use safe_execute_process to generate messages instead and prevent it from running every build to vastly improve build times.

Resolves https://github.com/swri-robotics/marti_common/issues/562