### PR TITLE
Fix TransformManager so it works in ROS2

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -137,7 +137,11 @@ install(PROGRAMS nodes/initialize_origin.py
 
 ament_python_install_package(${PROJECT_NAME})
 
-ament_export_dependencies(ament_cmake)
+ament_export_dependencies(
+  ament_cmake
+  geographic_msgs
+  gps_msgs
+)
 ament_export_include_directories(include
   ${YAML_CPP_INCLUDE_DIR}
 )

--- a/swri_transform_util/src/transform_manager.cpp
+++ b/swri_transform_util/src/transform_manager.cpp
@@ -153,7 +153,9 @@ namespace swri_transform_util
       geometry_msgs::msg::TransformStamped tf_transform;
       if (GetTransform(tgt_frame, src_frame, time, tf_transform))
       {
-        tf2::fromMsg(tf_transform, transform);
+        tf2::Stamped<tf2::Transform> tf_out;
+        tf2::fromMsg(tf_transform, tf_out);
+        transform = Transform(tf_out);
         return true;
       }
 


### PR DESCRIPTION
This fixes the usage of a templated function that was being called with
invalid arguments and also adds some necessary library exports.

Distribution Statement A; OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>