### PR TITLE
Replace boost::array with std::array

### DIFF
--- a/swri_transform_util/include/swri_transform_util/transform_util.h
+++ b/swri_transform_util/include/swri_transform_util/transform_util.h
@@ -31,7 +31,7 @@
 #define TRANSFORM_UTIL_TRANSFORM_UTIL_H_
 
 #include <string>
-#include <boost/array.hpp>
+#include <array>
 
 #include <tf2/transform_datatypes.h>
 #include <tf2/LinearMath/Transform.h>
@@ -179,7 +179,7 @@ namespace swri_transform_util
    *
    * @returns The upper-left 3x3 sub-matrix.
    */
-  tf2::Matrix3x3 GetUpperLeft(const boost::array<double, 36>& matrix);
+  tf2::Matrix3x3 GetUpperLeft(const std::array<double, 36>& matrix);
 
   /**
    * Gets the lower-right 3x3 sub-matrix of a 6x6 matrix.
@@ -188,7 +188,7 @@ namespace swri_transform_util
    *
    * @returns The lower-right 3x3 sub-matrix.
    */
-  tf2::Matrix3x3 GetLowerRight(const boost::array<double, 36>& matrix);
+  tf2::Matrix3x3 GetLowerRight(const std::array<double, 36>& matrix);
 
   /**
    * Converts the 3x3 covariance matrices from Imu messages to a Matrix3x3
@@ -197,7 +197,7 @@ namespace swri_transform_util
    *
    * @retval     Returns the input matrix as a Matrix3x3 object
    */
-  tf2::Matrix3x3 Get3x3Cov(const boost::array<double, 9>& matrix);
+  tf2::Matrix3x3 Get3x3Cov(const std::array<double, 9>& matrix);
 
   /**
    * Converts the Matrix3x3 matrix into a 9 element covariance matrix from Imu
@@ -208,7 +208,7 @@ namespace swri_transform_util
    *
    */
   void Set3x3Cov(const tf2::Matrix3x3& matrix_in,
-                          boost::array<double, 9>& matrix_out);
+                          std::array<double, 9>& matrix_out);
   /**
    * Sets the upper-left quadrant of a 6x6 matrix with the specified 3x3
    * sub-matrix
@@ -218,7 +218,7 @@ namespace swri_transform_util
    */
   void SetUpperLeft(
       const tf2::Matrix3x3& sub_matrix,
-      boost::array<double, 36>& matrix);
+      std::array<double, 36>& matrix);
 
   /**
    * Sets the lower-right quadrant of a 6x6 matrix with the specified 3x3
@@ -229,7 +229,7 @@ namespace swri_transform_util
    */
   void SetLowerRight(
       const tf2::Matrix3x3& sub_matrix,
-      boost::array<double, 36>& matrix);
+      std::array<double, 36>& matrix);
 
   /**
    * Calculate the subtending angle of an arc (aligned with the

--- a/swri_transform_util/src/transform_util.cpp
+++ b/swri_transform_util/src/transform_util.cpp
@@ -291,7 +291,7 @@ namespace swri_transform_util
     return true;
   }
 
-  tf2::Matrix3x3 GetUpperLeft(const boost::array<double, 36>& matrix)
+  tf2::Matrix3x3 GetUpperLeft(const std::array<double, 36>& matrix)
   {
     tf2::Matrix3x3 sub_matrix;
 
@@ -308,7 +308,7 @@ namespace swri_transform_util
     return sub_matrix;
   }
 
-  tf2::Matrix3x3 GetLowerRight(const boost::array<double, 36>& matrix)
+  tf2::Matrix3x3 GetLowerRight(const std::array<double, 36>& matrix)
   {
     tf2::Matrix3x3 sub_matrix;
 
@@ -325,7 +325,7 @@ namespace swri_transform_util
     return sub_matrix;
   }
 
-  tf2::Matrix3x3 Get3x3Cov(const boost::array<double, 9>& matrix)
+  tf2::Matrix3x3 Get3x3Cov(const std::array<double, 9>& matrix)
   {
     tf2::Matrix3x3 matrix_out;
 
@@ -344,7 +344,7 @@ namespace swri_transform_util
 
   void Set3x3Cov(
       const tf2::Matrix3x3& matrix_in,
-      boost::array<double, 9>& matrix_out)
+      std::array<double, 9>& matrix_out)
   {
     matrix_out[0] = matrix_in[0][0];
     matrix_out[1] = matrix_in[0][1];
@@ -359,7 +359,7 @@ namespace swri_transform_util
 
   void SetUpperLeft(
       const tf2::Matrix3x3& sub_matrix,
-      boost::array<double, 36>& matrix)
+      std::array<double, 36>& matrix)
   {
     matrix[0] = sub_matrix[0][0];
     matrix[1] = sub_matrix[0][1];
@@ -374,7 +374,7 @@ namespace swri_transform_util
 
   void SetLowerRight(
       const tf2::Matrix3x3& sub_matrix,
-      boost::array<double, 36>& matrix)
+      std::array<double, 36>& matrix)
   {
     matrix[21] = sub_matrix[0][0];
     matrix[22] = sub_matrix[0][1];

--- a/swri_transform_util/test/test_transform_util.cpp
+++ b/swri_transform_util/test/test_transform_util.cpp
@@ -29,7 +29,7 @@
 
 #include <cstdlib>
 
-#include <boost/array.hpp>
+#include <array.hpp>
 
 #include <gtest/gtest.h>
 
@@ -174,7 +174,7 @@ TEST(TransformUtilTests, TestUpperLeftLowerRight)
   tf::Matrix3x3 ul(1, 2, 3, 4, 5, 6, 7, 8, 9);
   tf::Matrix3x3 lr(10, 11, 12, 13, 14, 15, 16, 17, 18);
 
-  boost::array<double, 36> array;
+  std::array<double, 36> array;
 
   swri_transform_util::SetUpperLeft(ul, array);
   swri_transform_util::SetLowerRight(lr, array);


### PR DESCRIPTION
swri_transform_util was using boost::array, but ROS messages have switched to using std::array now.

Distribution Statement A; OPSEC #2893

Signed-off-by: P. J. Reed <preed@swri.org>