### PR TITLE
Fix build with Boost >=1.69

### DIFF
--- a/swri_opencv_util/src/show.cpp
+++ b/swri_opencv_util/src/show.cpp
@@ -64,7 +64,7 @@ namespace swri_opencv_util
       }
     }
 
-#if (BOOST_VERSION / 100 % 1000) >= 65
+#if (BOOST_VERSION / 100 % 1000) >= 65 && (BOOST_VERSION / 100 % 1000) < 69
     friend class boost::serialization::singleton<CvWindows>;
 #else
     friend class boost::serialization::detail::singleton_wrapper<CvWindows>;

--- a/swri_transform_util/include/swri_transform_util/utm_util.h
+++ b/swri_transform_util/include/swri_transform_util/utm_util.h
@@ -158,7 +158,7 @@ namespace swri_transform_util
           int zone, char band, double easting, double northing,
           double& latitude, double& longitude) const;
 
-#if (BOOST_VERSION / 100 % 1000) >= 65
+#if (BOOST_VERSION / 100 % 1000) >= 65 && (BOOST_VERSION / 100 % 1000) < 69
         friend class boost::serialization::singleton<swri_transform_util::UtmUtil::UtmData>;
 #else
         friend class boost::serialization::detail::singleton_wrapper<swri_transform_util::UtmUtil::UtmData>;


### PR DESCRIPTION
Boost 1.69 returns to using a `singleton_wrapper` class (see https://github.com/boostorg/serialization/commit/f297d80d6ef55ac66525320d0477c17806aa57cd), causing the build to fail.

This PR adds the necessary version checks to fix the build.