### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/marti_data_structures/CMakeLists.txt
+++ b/marti_data_structures/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(marti_data_structures)
 
 find_package(catkin REQUIRED)

--- a/swri_console_util/CMakeLists.txt
+++ b/swri_console_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_console_util)
 
 find_package(catkin REQUIRED COMPONENTS roscpp)

--- a/swri_dbw_interface/CMakeLists.txt
+++ b/swri_dbw_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_dbw_interface)
 
 find_package(catkin REQUIRED)

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(swri_geometry_util)
 

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_image_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_math_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_nodelet)
 
 set(BUILD_DEPS 

--- a/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
+++ b/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(swri_nodelet_SHARE ${swri_nodelet_PREFIX}/@CATKIN_PACKAGE_SHARE_DESTINATION@)
 

--- a/swri_opencv_util/CMakeLists.txt
+++ b/swri_opencv_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_opencv_util)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge swri_math_util)

--- a/swri_prefix_tools/CMakeLists.txt
+++ b/swri_prefix_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_prefix_tools)
 
 find_package(catkin REQUIRED)

--- a/swri_roscpp/CMakeLists.txt
+++ b/swri_roscpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(swri_roscpp)
 

--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(swri_roscpp_SHARE ${swri_roscpp_PREFIX}/@CATKIN_PACKAGE_SHARE_DESTINATION@)
 

--- a/swri_rospy/CMakeLists.txt
+++ b/swri_rospy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(swri_rospy)
 

--- a/swri_rospy/package.xml
+++ b/swri_rospy/package.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package format="2">
+<package format="3">
   <name>swri_rospy</name>
   <version>2.13.2</version>
   <description>
-  This package provides added functionaliy on top of rospy, including a
+  This package provides added functionality on top of rospy, including a
   single-threaded callback queue.
   </description>
   <maintainer email="preed@swri.edu">P. J. Reed</maintainer>
   <license>BSD</license>
+
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
+
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>

--- a/swri_rospy/setup.py
+++ b/swri_rospy/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_route_util)
 
 set(BUILD_DEPS 

--- a/swri_serial_util/CMakeLists.txt
+++ b/swri_serial_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_serial_util)
 
 find_package(catkin REQUIRED)

--- a/swri_string_util/CMakeLists.txt
+++ b/swri_string_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(swri_string_util)
 

--- a/swri_system_util/CMakeLists.txt
+++ b/swri_system_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_system_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_transform_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -1,4 +1,4 @@
-<package format="2">
+<package format="3">
   <name>swri_transform_util</name>
   <version>2.13.2</version>
   <description>
@@ -14,6 +14,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <depend>boost</depend>
   <depend>cv_bridge</depend>

--- a/swri_transform_util/setup.py
+++ b/swri_transform_util/setup.py
@@ -1,6 +1,6 @@
 ## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml

--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(swri_yaml_util)
 
 find_package(catkin REQUIRED)


### PR DESCRIPTION
Use setuptools instead of distutils ros/catkin#1048

In Ubuntu Focal `distutils` is not installed by default, so it might not be available. `ros-noetic-catkin` depends on `python3-setuptools`, so we know setuptools will be available.

This PR assumes `master` targets only ROS Noetic. If it actually covers kinetic and melodic, then both `setuptools` should be used and the `package.xml` for this package should be edited as described in the migration guide:

http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils

```xml
  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
```


