### PR TITLE
Improve topic service macro on ROS2

### DIFF
--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.0.2)
 
 set(swri_roscpp_BIN "${swri_roscpp_DIR}/../../../bin/")
 
-macro(generate_topic_service_files)
+macro(generate_topic_service_files generated_files_list)
   set(options NOINSTALL)
   set(oneValueArgs DIRECTORY)
-  set(multiValueArgs FILES DEPENDENCIES)
+  set(multiValueArgs FILES)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   if(ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR "generate_topic_service_files() called with unused arguments: ${ARG_UNPARSED_ARGUMENTS}")
@@ -49,10 +49,5 @@ macro(generate_topic_service_files)
 
   endforeach()
 
-  # Actually build our newly generated messages
-  rosidl_generate_interfaces(${PROJECT_NAME}
-    ${TMP_MSG_FILES}
-    DEPENDENCIES marti_common_msgs ${ARG_DEPENDENCIES}
-    ADD_LINTER_TESTS
-  )
+  set(${generated_files_list} ${TMP_MSG_FILES})
 endmacro()

--- a/swri_roscpp/readme.md
+++ b/swri_roscpp/readme.md
@@ -10,14 +10,16 @@ The usage is very similar to that of standard ROS services and can even make use
 
 ### Generating Topics from a Service
 
-In order to generate the backing topics for a Topic Service from a service message add a `generate_topic_service_files` block to your project's CMakeList.txt and use it almost the same way you would an `rosidl_generate_interfaces` block.
+In order to generate the backing topics for a Topic Service from a service message add a `generate_topic_service_files` block to your project's CMakeList.txt and use it almost the same way you would an `rosidl_generate_interfaces` block. This generates the individual topic service messages and returns a list of these to the variable named by the first argument. Make sure to add these to your rosidl_generate_interfaces call along with the marti_common_msgs dependency.
 
-Make sure to add this `swri_roscpp` as a dependency to your message project.
+Make sure to add `swri_roscpp` as a dependency to your message project.
 
 For example:
 
 ```cmake
-generate_topic_service_files(DIRECTORY topic_srv FILES
+generate_topic_service_files(generated_message_list
+ DIRECTORY topic_srv
+ FILES
   ClearActiveRoute.srv
   DeleteRoute.srv
   GetRoute.srv
@@ -26,8 +28,14 @@ generate_topic_service_files(DIRECTORY topic_srv FILES
   SetActiveRoute.srv
   SetRoute.srv
   SetNextCheckpoint.srv
-DEPENDENCIES
-  marti_common_msgs
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+   your_other_messages_here.msg
+   ${generated_message_list}
+  DEPENDENCIES 
+   ${MSG_DEPS}
+   marti_common_msgs
 )
 ```
 


### PR DESCRIPTION
Previously it would not work if you also generated other messages in the same project.