### PR TITLE
Fix header warnings

### DIFF
--- a/swri_image_util/src/nodes/blend_images_node.cpp
+++ b/swri_image_util/src/nodes/blend_images_node.cpp
@@ -31,7 +31,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>

--- a/swri_image_util/src/nodes/contrast_stretch_node.cpp
+++ b/swri_image_util/src/nodes/contrast_stretch_node.cpp
@@ -34,7 +34,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <swri_image_util/image_normalization.h>

--- a/swri_image_util/src/nodes/crosshairs_node.cpp
+++ b/swri_image_util/src/nodes/crosshairs_node.cpp
@@ -34,7 +34,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 

--- a/swri_image_util/src/nodes/draw_polygon_node.cpp
+++ b/swri_image_util/src/nodes/draw_polygon_node.cpp
@@ -30,7 +30,7 @@
 #include <string>
 
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>

--- a/swri_image_util/src/nodes/draw_text_node.cpp
+++ b/swri_image_util/src/nodes/draw_text_node.cpp
@@ -33,7 +33,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <swri_math_util/math_util.h>

--- a/swri_image_util/src/nodes/dummy_image_publisher_node.cpp
+++ b/swri_image_util/src/nodes/dummy_image_publisher_node.cpp
@@ -32,7 +32,7 @@
 // ROS Libraries
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/nodes/image_pub_node.cpp
+++ b/swri_image_util/src/nodes/image_pub_node.cpp
@@ -32,9 +32,9 @@
 #include <boost/make_shared.hpp>
 
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
-#include <image_transport/publisher.h>
-#include <image_transport/subscriber.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/publisher.hpp>
+#include <image_transport/subscriber.hpp>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/swri_image_util/src/nodes/normalization_image_node.cpp
+++ b/swri_image_util/src/nodes/normalization_image_node.cpp
@@ -42,7 +42,7 @@
 
 // RANGER Libraries
 #include <swri_image_util/image_normalization.h>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/nodes/normalize_response_node.cpp
+++ b/swri_image_util/src/nodes/normalize_response_node.cpp
@@ -33,7 +33,7 @@
 #include <opencv2/highgui/highgui.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <swri_image_util/image_normalization.h>

--- a/swri_image_util/src/nodes/rotate_image_node.cpp
+++ b/swri_image_util/src/nodes/rotate_image_node.cpp
@@ -32,7 +32,7 @@
 #include <opencv2/core/core.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 

--- a/swri_image_util/src/nodes/scale_image_node.cpp
+++ b/swri_image_util/src/nodes/scale_image_node.cpp
@@ -33,7 +33,7 @@
 #include <opencv2/imgproc/imgproc.hpp>
 
 #include <rclcpp/rclcpp.hpp>
-#include <image_transport/image_transport.h>
+#include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <swri_math_util/math_util.h>

--- a/swri_image_util/src/nodes/warp_image_node.cpp
+++ b/swri_image_util/src/nodes/warp_image_node.cpp
@@ -29,9 +29,9 @@
 
 #include <algorithm>
 #include <cv_bridge/cv_bridge.h>
-#include <image_transport/image_transport.h>
-#include <image_transport/publisher.h>
-#include <image_transport/subscriber.h>
+#include <image_transport/image_transport.hpp>
+#include <image_transport/publisher.hpp>
+#include <image_transport/subscriber.hpp>
 #include <opencv2/core/core.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>


### PR DESCRIPTION
I fixed a bunch of includes to remove deprecated headers to reduce the number of build warnings.

Distro A, OPSEC #4584