### PR TITLE
Fix bugs related to subscription age and setting timeout (#609, #611)

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -293,11 +293,7 @@ int Subscriber::messageCount() const
 inline
 rclcpp::Duration Subscriber::age(const rclcpp::Time &now) const
 {
-  if (now == rclcpp::Time(0, 0)) {
-    return impl_->age(rclcpp::Clock().now());
-  } else {
-    return impl_->age(now);
-  }
+  return impl_->age(now);
 }
 
 inline
@@ -399,7 +395,7 @@ void Subscriber::setTimeout(const rclcpp::Duration &time_out)
 inline
 void Subscriber::setTimeout(const double time_out)
 {
-  setTimeout(rclcpp::Duration(time_out));
+  setTimeout(std::chrono::duration<double>(time_out));
 }
 
 inline

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -169,6 +169,8 @@ namespace swri
     {
       if (message_count_ < 1) {
         return rclcpp::Duration::max();
+      } else if (now == rclcpp::Time(0, 0)) {
+        return nh_->now() - last_header_stamp_;
       } else {
         return now - last_header_stamp_;
       }


### PR DESCRIPTION
#609 - The original code used rclcpp::Clock::now() to retrieve the time, which returns a clock of type RCL_SYSTEM_TIME. All other code is using rclcpp::Node::now() which returns a clock of type RCL_ROS_TIME. The two time sources are not compatible and cannot be compared or operated on together. This change pushes the code down into the impl where the node handle is available for calling now() when now is not provided as an argument.  It is worth noting that calling age(node->now()) instead of age() is not even possible as a workaround since that will result in another exception due to the passed time object source not being compatible with rclcpp::Time(0,0). Similar "what" text as the original problem, just having to do with comparing to unlike time sources.

#611 - There is no constructor for rclcpp::Duration that takes a double.  Convert to a std::chrono::duration<double> before passing to the setTimeout() function that takes a rclcpp::Duration.
