### PR TITLE
Issue #609 complete fix

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -116,9 +116,9 @@ class Subscriber
   // Age of the most recent message (difference between now and the
   // header stamp (or time message was received for messages that
   // don't have headers).
-  rclcpp::Duration age(const rclcpp::Time &now = rclcpp::Time(0,0)) const;
-  double ageSeconds(const rclcpp::Time &now = rclcpp::Time(0,0)) const;
-  double ageMilliseconds(const rclcpp::Time &now = rclcpp::Time(0,0)) const;
+  rclcpp::Duration age(const rclcpp::Time &now = rclcpp::Time(0,0,RCL_ROS_TIME)) const;
+  double ageSeconds(const rclcpp::Time &now = rclcpp::Time(0,0,RCL_ROS_TIME)) const;
+  double ageMilliseconds(const rclcpp::Time &now = rclcpp::Time(0,0,RCL_ROS_TIME)) const;
 
   // Average latency (time difference between the time stamp and when
   // the message is received). These will be useless for message types

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -169,7 +169,7 @@ namespace swri
     {
       if (message_count_ < 1) {
         return rclcpp::Duration::max();
-      } else if (now == rclcpp::Time(0, 0)) {
+      } else if (now == rclcpp::Time(0,0,RCL_ROS_TIME)) {
         return nh_->now() - last_header_stamp_;
       } else {
         return now - last_header_stamp_;


### PR DESCRIPTION
The original fix for #609 was incomplete.

Using rclcpp::Time(0,0) as a default value instead of rclcpp::Time(0,0,RCL_ROS_TIME) causes an exception when now is comparing to rclcpp::Time(0,0) on line 169 since "now" is typically a RCL_ROS_TIME source because it is grabbed from nh_->now().   This PR should fix that.
