### PR TITLE
Fix usage of yaml_include_dirs

### DIFF
--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -29,7 +29,7 @@ include_directories(include)
 include_directories(SYSTEM
   ${catkin_INCLUDE_DIRS}
   ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-  ${YamlCpp_INCLUDE_DIR}
+  ${YamlCpp_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
This fixes the build in the RoboStack project: https://github.com/robostack/ros-noetic