### PR TITLE
Modify swri_math_util to add shared library instead of static library

### DIFF
--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -9,9 +9,9 @@ find_package(rclcpp REQUIRED)
 
 # The Boost Random library headers and namespaces changed between version
 # 1.46 and 1.47
-find_package(Boost COMPONENTS random) 
+find_package(Boost COMPONENTS random)
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/math_util.cpp
   src/trig_util.cpp
   src/random.cpp


### PR DESCRIPTION
From what I have seen in a project that I am working on, making the library shared should facilitate linking with other shared libraries.

The whitespace change in line 12 is because I have VSCode set up to remove trailing whitespaces when saving a file.