### PR TITLE
Adding tf2_geometry_msgs as dependency

### DIFF
--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(swri_geometry_util REQUIRED)
 find_package(swri_math_util REQUIRED)
 find_package(swri_roscpp REQUIRED)
 find_package(swri_transform_util REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 ### Build Library ###
@@ -36,6 +37,7 @@ ament_target_dependencies(${PROJECT_NAME}
   swri_math_util
   swri_roscpp
   swri_transform_util
+  tf2_geometry_msgs
   visualization_msgs
 )
 

--- a/swri_route_util/package.xml
+++ b/swri_route_util/package.xml
@@ -21,6 +21,7 @@
   <depend>swri_math_util</depend>
   <depend>swri_geometry_util</depend>
   <depend>swri_roscpp</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <export>


### PR DESCRIPTION
Adds tf2_geometry_msgs as a missing dependency, since swri_route_util/route_point_inline.h references it.