### PR TITLE
swri_yaml_util: fix compatibility with yaml-cpp 0.7.0

### DIFF
--- a/swri_yaml_util/src/yaml_util.cpp
+++ b/swri_yaml_util/src/yaml_util.cpp
@@ -169,7 +169,7 @@ namespace swri_yaml_util
   bool FindValue(const YAML::Node& node, const std::string& name)
   {
     #ifndef YAMLCPP_OLD_API
-      return node[name];
+      return static_cast<bool>(node[name]);
     #else
       return node.FindValue(name);
     #endif  // YAMLCPP_OLD_API


### PR DESCRIPTION
`YAML::Node`'s bool operator was made explicit, so a cast is needed. See: https://github.com/jbeder/yaml-cpp/issues/822