### PR TITLE
swri_transform_util: try to find PROJ with CMake

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -23,8 +23,18 @@ catkin_python_setup()
 find_package(OpenCV  REQUIRED calib3d core highgui imgproc video)
 find_package(Boost REQUIRED COMPONENTS filesystem serialization thread)
 
+# First try pkg-config. Should always work for PROJ >= 8. Should work with older
+# versions if they were installed with autotools
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROJ proj)
+
+# Next, try CMake, which should work if PROJ was installed with CMake
+if(NOT "${PROJ_FOUND}")
+  unset(PROJ_FOUND CACHE)
+  find_package(PROJ)
+endif()
+
+# Lastly, try to find the library directly, for backwards compatibility
 if(NOT "${PROJ_FOUND}")
   set(PROJ_INCLUDE_DIRS /usr/include)
   set(PROJ_LIBRARY_DIRS /usr/lib)


### PR DESCRIPTION
PROJ provides CMake config files when installed with CMake (rather than autotools, as is done in Debian/Ubuntu). Versions older than 8 (which isn't compatible with `swri_transform_util`) don't install a pkg-config file when installed with CMake. Therefore, the build currently fails to find PROJ on systems where it is install with CMake to a directory other than `/usr`.

This patch causes all three methods to be tried in sequence, so should be compatible with all these possibilities. I don't see why using `find_library()` would ever be necessary, but I kept it to maintain compatibility.