### PR TITLE
Add const callback method overloads to subscribe for swri nodehandle

### DIFF
--- a/swri_roscpp/include/swri_roscpp/node_handle.h
+++ b/swri_roscpp/include/swri_roscpp/node_handle.h
@@ -604,6 +604,33 @@ public:
     return nh_->nh_.subscribe(real_name, queue_size, fp, obj, transport_hints);
   }
 
+  // The const class method overload
+  template<class M , class T >
+  ros::Subscriber subscribe(const std::string &name,
+             uint32_t queue_size,
+             void(T::*fp)(const boost::shared_ptr< M const > &) const,
+             T *obj,
+             const std::string description,
+             const ros::TransportHints &transport_hints=ros::TransportHints())
+  {
+    std::string real_name = resolveName(name);
+    if (nh_->enable_docs_)
+    {
+      const std::string resolved_name = nh_->nh_.resolveName(real_name);
+      marti_introspection_msgs::TopicInfo info;
+      info.name = real_name;
+      info.resolved_name = resolved_name;
+      info.group = grouping_;
+      info.message_type = ros::message_traits::DataType<M>().value();
+      info.advertised = false;
+      info.description = description;
+      nh_->info_msg_.topics.push_back(info);
+      nh_->info_pub_.publish(nh_->info_msg_);
+    }
+
+    return nh_->nh_.subscribe(real_name, queue_size, fp, obj, transport_hints);
+  }
+
   // Using boost function callback.
   template<class M>
   ros::Subscriber subscribe(const std::string &name,
@@ -635,6 +662,33 @@ public:
   ros::Subscriber subscribe(const std::string &name,
              uint32_t queue_size,
              void(T::*fp)(const ros::MessageEvent< M const > &),
+             T *obj,
+             const std::string description,
+             const ros::TransportHints &transport_hints=ros::TransportHints())
+  {
+    std::string real_name = resolveName(name);
+    if (nh_->enable_docs_)
+    {
+      const std::string resolved_name = nh_->nh_.resolveName(real_name);
+      marti_introspection_msgs::TopicInfo info;
+      info.name = real_name;
+      info.resolved_name = resolved_name;
+      info.group = grouping_;
+      info.message_type = ros::message_traits::DataType<M>().value();
+      info.advertised = false;
+      info.description = description;
+      nh_->info_msg_.topics.push_back(info);
+      nh_->info_pub_.publish(nh_->info_msg_);
+    }
+
+    return nh_->nh_.subscribe(real_name, queue_size, fp, obj, transport_hints);
+  }
+
+  // Using const class method callback.
+  template<class M , class T >
+  ros::Subscriber subscribe(const std::string &name,
+             uint32_t queue_size,
+             void(T::*fp)(const ros::MessageEvent< M const > &) const,
              T *obj,
              const std::string description,
              const ros::TransportHints &transport_hints=ros::TransportHints())


### PR DESCRIPTION
Added overloads for `swri::NodeHandle::subscribe` for:
- callback type: `void(T::*fp)(const boost::shared_ptr< M const > &) const`
- callback type: `void(T::*fp)(const ros::MessageEvent< M const > &) const`

Currently `swri::Subscriber` does not support const class methods as callback types either. Changing the `swri::NodeHandle::subscribe_swri` and the `swri::Subscribe` APIs will require another constructor overload for `swri::Subscriber`