### PR TITLE
Replace ambiguous python shebangs

### DIFF
--- a/swri_prefix_tools/xterm_prefix
+++ b/swri_prefix_tools/xterm_prefix
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import os
 import time

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2017, Southwest Research Institute (SwRI)


### PR DESCRIPTION
ROS 2 only supports Python 3. It would be best if these Python scripts didn't use an ambigous python interpreter, and specifically looked for a Python 3 interpreter.

This should resolve RPM build failures on RHEL like this one: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__swri_prefix_tools__rhel_8_x86_64__binary