### PR TITLE
Add missing header.

### DIFF
--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -30,6 +30,7 @@
 #define SWRI_ROSCPP_TOPIC_SERVICE_CLIENT_H_
 
 #include <ros/node_handle.h>
+#include <ros/this_node.h>
 
 #include <boost/thread/mutex.hpp>
 #include <boost/uuid/random_generator.hpp>


### PR DESCRIPTION
Adds the `ros/this_node.h` header to `topic_service_client.h`, which should fix the issue pointed out in #653.

Fixes #653.