### PR TITLE
Make local xy subscription latching

### DIFF
--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -107,9 +107,11 @@ namespace swri_transform_util
   void LocalXyWgs84Util::ResetInitialization()
   {
     std::string type;
+    rclcpp::QoS latching_qos(1);
+    latching_qos.transient_local();
     pose_sub_ = node_->create_subscription<geometry_msgs::msg::PoseStamped>(
         "/local_xy_origin",
-        1,
+        latching_qos,
         std::bind(&LocalXyWgs84Util::HandlePoseStamped, this, std::placeholders::_1));
     initialized_ = false;
   }


### PR DESCRIPTION
In ROS2, QoS policies need to match otherwise subscribers may not get messages. This just updates the local xy subscriber to use transient_local QoS