### PR TITLE
Make Topic Service Client Optionally Spin

### DIFF
--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -141,9 +141,7 @@ public:
 
   bool call(MReq& request, MRes& response)
   {
-    RCLCPP_ERROR(node_->get_logger(), "Starting call");
     std::lock_guard<std::mutex> scoped_lock(request_lock_);
-    RCLCPP_ERROR(node_->get_logger(), "Locked mutex");
 
     // block for response
     request.srv_header.stamp = node_->now();
@@ -151,9 +149,7 @@ public:
     request.srv_header.sender = name_;
 
     response_.reset();
-    RCLCPP_ERROR(node_->get_logger(), "Publishing request");
     request_pub_->publish(request);
-    RCLCPP_ERROR(node_->get_logger(), "Request published");
 
     // Inspired by process in ClientBase::wait_for_service_nanoseconds in client.cpp
     auto start = std::chrono::steady_clock::now();
@@ -162,15 +158,12 @@ public:
     {
       time_to_wait = timeout_ - (std::chrono::steady_clock::now() - start);
     }
-    RCLCPP_ERROR(node_->get_logger(), "Calculated time to wait");
 
     // Wait until we get a response
     do
     {
-      RCLCPP_ERROR(node_->get_logger(), "Top of loop");
       if (!rclcpp::ok())
       {
-        RCLCPP_ERROR(node_->get_logger(), "rclcpp was not okay");
         return false;
       }
 
@@ -181,15 +174,11 @@ public:
 
       if (timeout_ > std::chrono::nanoseconds(0))
       {
-        RCLCPP_ERROR(node_->get_logger(), "Updating time to wait");
         time_to_wait = timeout_ - (std::chrono::steady_clock::now() - start);
         rclcpp::sleep_for(std::chrono::milliseconds(2));
-        RCLCPP_ERROR(node_->get_logger(), "Done sleeping");
         if (internal_spin_)
         {
-          RCLCPP_ERROR(node_->get_logger(), "Spinning");
           rclcpp::spin_some(node_);
-          RCLCPP_ERROR(node_->get_logger(), "Done spinning");
         }
       }
     } while (!response_ && (time_to_wait > std::chrono::nanoseconds(0)));
@@ -197,14 +186,12 @@ public:
     sequence_++;
     if (response_)
     {
-      RCLCPP_ERROR(node_->get_logger(), "Got result, %u", response_->srv_header.result);
       response = *response_;
       response_.reset();
       return response.srv_header.result;
     }
     else
     {
-      RCLCPP_ERROR(node_->get_logger(), "No result");
       return false;
     }
   }

--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -31,8 +31,8 @@
 
 #include <chrono>
 #include <map>
+#include <mutex>
 
-#include <boost/thread/mutex.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
@@ -46,7 +46,7 @@ template<class MReq, class MRes>
 class TopicServiceClientRaw
 {
 private:
-  boost::mutex request_lock_;
+  std::mutex request_lock_;
   std::shared_ptr<rclcpp::Subscription<MRes> > response_sub_;
   std::shared_ptr<rclcpp::Publisher<MReq> > request_pub_;
   std::shared_ptr<MRes> response_;
@@ -130,7 +130,7 @@ public:
 
   bool call(MReq& request, MRes& response)
   {
-    boost::mutex::scoped_lock scoped_lock(request_lock_);
+    std::lock_guard<std::mutex> scoped_lock(request_lock_);
 
     // block for response
     request.srv_header.stamp = node_->now();

--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -203,7 +203,7 @@ public:
   template<typename RepT = int64_t, typename RatioT = std::milli>
   bool
   wait_for_service(
-    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration<RepT, RatioT>(std::chrono::nanoseconds(1s)))
+    std::chrono::duration<RepT, RatioT> timeout = std::chrono::duration(std::chrono::nanoseconds(1s)))
   {
     return TopicServiceClientRaw<typename MReq::Request, typename MReq::Response>::wait_for_service_nanoseconds(
       std::chrono::duration_cast<std::chrono::nanoseconds>(timeout));

--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -127,7 +127,7 @@ public:
         rclcpp::sleep_for(std::chrono::milliseconds(2));
         if (internal_spin_)
         {
-          rclcpp::spin_some(node_->shared_from_this());
+          rclcpp::spin_some(node_);
         }
       }
     } while (time_to_wait > std::chrono::nanoseconds(0));
@@ -178,7 +178,7 @@ public:
         rclcpp::sleep_for(std::chrono::milliseconds(2));
         if (internal_spin_)
         {
-          rclcpp::spin_some(node_->shared_from_this());
+          rclcpp::spin_some(node_);
         }
       }
     } while (time_to_wait > std::chrono::nanoseconds(0));

--- a/swri_roscpp/include/swri_roscpp/topic_service_client.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_client.h
@@ -141,7 +141,9 @@ public:
 
   bool call(MReq& request, MRes& response)
   {
+    RCLCPP_ERROR(node_->get_logger(), "Starting call");
     std::lock_guard<std::mutex> scoped_lock(request_lock_);
+    RCLCPP_ERROR(node_->get_logger(), "Locked mutex");
 
     // block for response
     request.srv_header.stamp = node_->now();
@@ -149,7 +151,9 @@ public:
     request.srv_header.sender = name_;
 
     response_.reset();
+    RCLCPP_ERROR(node_->get_logger(), "Publishing request");
     request_pub_->publish(request);
+    RCLCPP_ERROR(node_->get_logger(), "Request published");
 
     // Inspired by process in ClientBase::wait_for_service_nanoseconds in client.cpp
     auto start = std::chrono::steady_clock::now();
@@ -158,40 +162,49 @@ public:
     {
       time_to_wait = timeout_ - (std::chrono::steady_clock::now() - start);
     }
+    RCLCPP_ERROR(node_->get_logger(), "Calculated time to wait");
 
     // Wait until we get a response
     do
     {
+      RCLCPP_ERROR(node_->get_logger(), "Top of loop");
       if (!rclcpp::ok())
       {
+        RCLCPP_ERROR(node_->get_logger(), "rclcpp was not okay");
         return false;
       }
 
       if (response_)
       {
-        return true;
+        break;
       }
 
       if (timeout_ > std::chrono::nanoseconds(0))
       {
+        RCLCPP_ERROR(node_->get_logger(), "Updating time to wait");
         time_to_wait = timeout_ - (std::chrono::steady_clock::now() - start);
         rclcpp::sleep_for(std::chrono::milliseconds(2));
+        RCLCPP_ERROR(node_->get_logger(), "Done sleeping");
         if (internal_spin_)
         {
+          RCLCPP_ERROR(node_->get_logger(), "Spinning");
           rclcpp::spin_some(node_);
+          RCLCPP_ERROR(node_->get_logger(), "Done spinning");
         }
       }
-    } while (time_to_wait > std::chrono::nanoseconds(0));
+    } while (!response_ && (time_to_wait > std::chrono::nanoseconds(0)));
 
     sequence_++;
     if (response_)
     {
+      RCLCPP_ERROR(node_->get_logger(), "Got result, %u", response_->srv_header.result);
       response = *response_;
       response_.reset();
       return response.srv_header.result;
     }
     else
     {
+      RCLCPP_ERROR(node_->get_logger(), "No result");
       return false;
     }
   }

--- a/swri_roscpp/include/swri_roscpp/topic_service_server.h
+++ b/swri_roscpp/include/swri_roscpp/topic_service_server.h
@@ -54,17 +54,17 @@ public:
     node_(nullptr)
   {}
 
-  void initialize(rclcpp::Node &nh,
+  void initialize(rclcpp::Node::SharedPtr nh,
               const std::string &service,
               bool(T::*srv_func)(const MReq &, MRes &),
               T *obj)
   {
-    node_ = &nh;
+    node_ = nh;
     callback_ = srv_func;
     obj_ = obj;
 
-    response_pub_ = nh.create_publisher<MRes>(service + "/response", 10);
-    request_sub_ = nh.create_subscription<MReq>(service + "/request",
+    response_pub_ = node_->create_publisher<MRes>(service + "/response", 10);
+    request_sub_ = node_->create_subscription<MReq>(service + "/request",
         10, std::bind(&TopicServiceServerImpl<MReq, MRes, T>::request_callback, this, std::placeholders::_1));
   }
 
@@ -84,7 +84,7 @@ private:
     response_pub_->publish(response);
   }
 
-  rclcpp::Node* node_;
+  rclcpp::Node::SharedPtr node_;
 };
 
 class TopicServiceServer
@@ -97,7 +97,7 @@ class TopicServiceServer
   TopicServiceServer() = default;
 
   template<class MReq, class MRes, class T>
-  void initialize(rclcpp::Node &nh,
+  void initialize(rclcpp::Node::SharedPtr nh,
                 const std::string &service,
                 bool(T::*srv_func)(const MReq&, MRes&),
                 T *obj);
@@ -105,7 +105,7 @@ class TopicServiceServer
 
 template<class MReq, class MRes, class T>
 inline
-void TopicServiceServer::initialize(rclcpp::Node &nh,
+void TopicServiceServer::initialize(rclcpp::Node::SharedPtr nh,
                           const std::string &service,
                           bool(T::*srv_func)(const MReq&, MRes&),
                           T *obj)

--- a/swri_roscpp/test/topic_service_test.cpp
+++ b/swri_roscpp/test/topic_service_test.cpp
@@ -72,7 +72,7 @@ namespace swri_roscpp
   class TopicServiceHandler
   {
   public:
-    TopicServiceHandler(rclcpp::Node* node) :
+    TopicServiceHandler(rclcpp::Node::SharedPtr node) :
       node_(node),
       call_count_(0),
       error_(false),
@@ -101,7 +101,7 @@ namespace swri_roscpp
       return is_running_;
     }
 
-    rclcpp::Node* node_;
+    rclcpp::Node::SharedPtr node_;
     int call_count_;
     bool error_;
     bool is_running_;
@@ -117,11 +117,11 @@ public:
 
   void DoStuff()
   {
-    swri_roscpp::TopicServiceHandler handler(this);
+    swri_roscpp::TopicServiceHandler handler(this->shared_from_this());
 
     swri::TopicServiceServer server;
     server.initialize(
-        *this,
+        this->shared_from_this(),
         swri_roscpp::topic_name,
         &swri_roscpp::TopicServiceHandler::handleTopicServiceRequest,
         &handler);

--- a/swri_roscpp/test/topic_service_test.cpp
+++ b/swri_roscpp/test/topic_service_test.cpp
@@ -155,7 +155,7 @@ public:
     swri::TopicServiceClient<swri_roscpp::msg::TestTopicService> client;
     client.initialize(this->shared_from_this(), swri_roscpp::topic_name, "test_client");
 
-    client.wait_for_service();
+    client.wait_for_service(std::chrono::seconds(1));
     ASSERT_TRUE(client.exists());
 
     swri_roscpp::msg::TestTopicService srv;

--- a/swri_roscpp/test/topic_service_test.cpp
+++ b/swri_roscpp/test/topic_service_test.cpp
@@ -155,14 +155,7 @@ public:
     swri::TopicServiceClient<swri_roscpp::msg::TestTopicService> client;
     client.initialize(this->shared_from_this(), swri_roscpp::topic_name, "test_client");
 
-    int checks = 0;
-    // Wait up to 20s for the server to exist (it should be much faster than that)
-    while (!client.exists() && checks < 20)
-    {
-      RCLCPP_INFO(this->get_logger(), "Waiting for server to exist...");
-      rclcpp::sleep_for(std::chrono::seconds(1));
-      checks++;
-    }
+    client.wait_for_service();
     ASSERT_TRUE(client.exists());
 
     swri_roscpp::msg::TestTopicService srv;

--- a/swri_roscpp/test/topic_service_test.cpp
+++ b/swri_roscpp/test/topic_service_test.cpp
@@ -153,7 +153,7 @@ public:
   void DoStuff()
   {
     swri::TopicServiceClient<swri_roscpp::msg::TestTopicService> client;
-    client.initialize(*this, swri_roscpp::topic_name, "test_client");
+    client.initialize(this->shared_from_this(), swri_roscpp::topic_name, "test_client");
 
     int checks = 0;
     // Wait up to 20s for the server to exist (it should be much faster than that)


### PR DESCRIPTION
Adds the ability to have the topic service client either spin itself, or have an external source of spinning the callbacks.