### PR TITLE
Fix ament exports

### DIFF
--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -35,6 +35,7 @@ if ("$ENV{ROS_DISTRO}" STRLESS_EQUAL "galactic")
 endif()
 
 ament_target_dependencies(${PROJECT_NAME}
+  PUBLIC
   ament_cmake
   marti_common_msgs
   marti_nav_msgs
@@ -62,5 +63,5 @@ install(DIRECTORY include/
 ament_export_dependencies(ament_cmake)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
-
 ament_package()
+

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(${PROJECT_NAME}
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE
+  PUBLIC
     USE_NEW_TF2_TOMSG=${USE_NEW_TF2_TOMSG}
 )
 
@@ -76,6 +76,7 @@ if ("$ENV{ROS_DISTRO}" STRLESS_EQUAL "galactic")
 endif()
 
 target_link_libraries(${PROJECT_NAME}
+  PUBLIC
   Boost::boost
   Boost::filesystem
   Boost::thread
@@ -88,6 +89,7 @@ target_link_libraries(${PROJECT_NAME}
   yaml-cpp
 )
 ament_target_dependencies(${PROJECT_NAME}
+  PUBLIC
   diagnostic_msgs
   diagnostic_updater
   geographic_msgs
@@ -117,27 +119,27 @@ target_include_directories(${PROJECT_NAME}_nodes
   INTERFACE
   ${PROJ_INCLUDE_DIRS}
 )
+
+set(TF_UTIL_DEFINITIONS "")
 if ("$ENV{ROS_DISTRO}" STRLESS_EQUAL "galactic")
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "-DUSE_TF2_H_FILES")
-  target_compile_definitions(${PROJECT_NAME}_nodes
-    PRIVATE "-DUSE_TF2_H_FILES")
+  set(TF_UTIL_DEFINITIONS "-DUSE_TF2_H_FILES ${TF_UTIL_DEFINITIONS}")
 endif()
 
 if ("$ENV{ROS_DISTRO}" STRGREATER "galactic")
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "-DUSE_PROJ_API_6")
-  target_compile_definitions(${PROJECT_NAME}_nodes
-    PRIVATE "-DUSE_PROJ_API_6")
+  set(TF_UTIL_DEFINITIONS "-DUSE_PROJ_API_6 ${TF_UTIL_DEFINITIONS}")
 endif()
 
 # Workaround to https://github.com/ros2/geometry2/pull/427
 if (("$ENV{ROS_DISTRO}" STREQUAL "rolling") OR ("$ENV{ROS_DISTRO}" STREQUAL "humble"))
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "-DFROM_MSG_WORKAROUND")
-  target_compile_definitions(${PROJECT_NAME}_nodes
-    PRIVATE "-DFROM_MSG_WORKAROUND")
+  set(TF_UTIL_DEFINITIONS "-DFROM_MSG_WORKAROUND ${TF_UTIL_DEFINITIONS}")
 endif()
+
+target_compile_definitions(${PROJECT_NAME}
+  PUBLIC "${TF_UTIL_DEFINITIONS}"
+  )
+target_compile_definitions(${PROJECT_NAME}_nodes
+  PRIVATE "${TF_UTIL_DEFINITIONS}"
+  )
 
 target_compile_definitions(${PROJECT_NAME}_nodes
   PRIVATE "COMPOSITION_BUILDING_DLL")
@@ -220,15 +222,19 @@ install(PROGRAMS nodes/initialize_origin.py
 )
 
 ament_python_install_package(${PROJECT_NAME})
-
+ament_export_definitions("${TF_UTIL_DEFINITIONS}")
 ament_export_dependencies(
   ament_cmake
   geographic_msgs
   gps_msgs
+  tf2_geometry_msgs
 )
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}
+  Boost::boost
+  Boost::filesystem
+  Boost::thread
   ${PROJ_LIBRARIES}
 )
-
 ament_package()
+

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -231,9 +231,6 @@ ament_export_dependencies(
 )
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}
-  Boost::boost
-  Boost::filesystem
-  Boost::thread
   ${PROJ_LIBRARIES}
 )
 ament_package()

--- a/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
+++ b/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
@@ -33,6 +33,38 @@
 
 #ifndef FROM_MSG_WORKAROUND
 #include <tf2/utils.h>
+#else
+#include <geometry_msgs/msg/quaternion.hpp>
+namespace tf2 {
+  inline
+  double getYaw(const geometry_msgs::msg::Quaternion & q)
+  {
+    double yaw;
+
+    double sqw;
+    double sqx;
+    double sqy;
+    double sqz;
+
+    sqx = q.x * q.x;
+    sqy = q.y * q.y;
+    sqz = q.z * q.z;
+    sqw = q.w * q.w;
+
+    // Cases derived from https://orbitalstation.wordpress.com/tag/quaternion/
+    // normalization added from urdfom_headers
+    double sarg = -2 * (q.x * q.z - q.w * q.y) / (sqx + sqy + sqz + sqw);
+
+    if (sarg <= -0.99999) {
+      yaw = -2 * atan2(q.y, q.x);
+    } else if (sarg >= 0.99999) {
+      yaw = 2 * atan2(q.y, q.x);
+    } else {
+      yaw = atan2(2 * (q.x * q.y + q.w * q.z), sqw + sqx - sqy - sqz);
+    }
+    return yaw;
+  }
+}
 #endif
 
 #ifdef USE_TF2_H_FILES


### PR DESCRIPTION
The swri_route_util and swri_transform_util packages needs to export their definitions and include paths properly in order for other components to be able to import them.

Signed-off-by: P. J. Reed <phillipreed@hatchbed.com>