### PR TITLE
Fixing how the GEOS library is found

### DIFF
--- a/swri_geometry_util/FindGEOS.cmake
+++ b/swri_geometry_util/FindGEOS.cmake
@@ -46,7 +46,7 @@ IF (NOT DEFINED GEOS_INCLUDE_DIR OR NOT DEFINED GEOS_LIBRARY OR NOT DEFINED GEOS
             OUTPUT_VARIABLE GEOS_PREFIX)
 
         FIND_PATH(GEOS_INCLUDE_DIR
-            geos/geom.h
+            geos_c.h
             PATHS
                 ${GEOS_PREFIX}/include
                 /usr/local/include


### PR DESCRIPTION
When we switched to the GEOS C library in the prior release we did not update the FindGEOS.cmake file, and as a result, it will not find the GEOS library if the C++ version is not installed.