### PR TITLE
WIP: Fix dependencies

### DIFF
--- a/swri_roscpp/CMakeLists.txt
+++ b/swri_roscpp/CMakeLists.txt
@@ -14,16 +14,22 @@ find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
-# TODO pjr What to do about swri_roscpp-extras.cmake?
 add_library(${PROJECT_NAME} INTERFACE)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
+target_link_libraries(${PROJECT_NAME} INTERFACE
+  ${diagnostic_updater_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${std_msgs_LIBRARIES}
+)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>"
+  ${rclcpp_INCLUDE_DIRS}
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT "export_${PROJECT_NAME}"
+  EXPORT "${PROJECT_NAME}Targets"
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib
@@ -34,70 +40,93 @@ install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
 )
 
-ament_export_targets("export_${PROJECT_NAME}")
+ament_export_targets("${PROJECT_NAME}Targets" HAS_LIBRARY_TARGET)
 
-# ### Build Test Node ###
+ament_export_dependencies(ament_cmake)
+ament_export_dependencies(diagnostic_updater)
+ament_export_dependencies(marti_common_msgs)
+ament_export_dependencies(nav_msgs)
+ament_export_dependencies(rclcpp)
+ament_export_dependencies(std_msgs)
+ament_export_dependencies(std_srvs)
+
+# ### Build Test Nodes ###
 add_executable(subscriber_test src/nodes/subscriber_test.cpp)
+target_compile_features(subscriber_test PRIVATE cxx_std_17)
 target_include_directories(subscriber_test
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${diagnostic_updater_INCLUDE_DIRS}
+  ${nav_msgs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
-ament_target_dependencies(subscriber_test
-  diagnostic_updater
-  marti_common_msgs
-  nav_msgs
-  rclcpp
-  std_msgs
-  std_srvs
+target_link_libraries(subscriber_test
+  ${diagnostic_updater_LIBRARIES}
+  ${marti_common_msgs_LIBRARIES}
+  ${nav_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${std_msgs_LIBRARIES}
+  ${std_srvs_LIBRARIES}
 )
 
 add_executable(storing_subscriber_test src/nodes/storing_subscriber_test.cpp)
+target_compile_features(storing_subscriber_test PRIVATE cxx_std_17)
 target_include_directories(storing_subscriber_test
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${diagnostic_updater_INCLUDE_DIRS}
+  ${nav_msgs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
-ament_target_dependencies(storing_subscriber_test
-  diagnostic_updater
-  marti_common_msgs
-  nav_msgs
-  rclcpp
-  std_msgs
-  std_srvs
+target_link_libraries(storing_subscriber_test
+  ${diagnostic_updater_LIBRARIES}
+  ${marti_common_msgs_LIBRARIES}
+  ${nav_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${std_msgs_LIBRARIES}
+  ${std_srvs_LIBRARIES}
   )
 
 add_executable(service_server_test src/nodes/service_server_test.cpp)
+target_compile_features(service_server_test PRIVATE cxx_std_17)
 target_include_directories(service_server_test
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${diagnostic_updater_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${std_srvs_INCLUDE_DIRS}
 )
-ament_target_dependencies(service_server_test
-  diagnostic_updater
-  marti_common_msgs
-  nav_msgs
-  rclcpp
-  std_msgs
-  std_srvs
+target_link_libraries(service_server_test
+  ${diagnostic_updater_LIBRARIES}
+  ${marti_common_msgs_LIBRARIES}
+  ${nav_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${std_msgs_LIBRARIES}
+  ${std_srvs_LIBRARIES}
   )
 
 add_executable(timer_test src/nodes/timer_test.cpp)
+target_compile_features(timer_test PRIVATE cxx_std_17)
 target_include_directories(timer_test
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  ${diagnostic_updater_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
-ament_target_dependencies(timer_test
-  diagnostic_updater
-  marti_common_msgs
-  nav_msgs
-  rclcpp
-  std_msgs
-  std_srvs
+target_link_libraries(timer_test
+  ${diagnostic_updater_LIBRARIES}
+  ${marti_common_msgs_LIBRARIES}
+  ${nav_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${std_msgs_LIBRARIES}
+  ${std_srvs_LIBRARIES}
   )
 
-  # Disabling Foxy and Galactic tests until https://github.com/ros2/rosidl/pull/639 is merged
+# Disabling Foxy and Galactic tests until https://github.com/ros2/rosidl/pull/639 is merged
 if (BUILD_TESTING AND ("$ENV{ROS_DISTRO}" STRGREATER "galactic"))
   find_package(ament_cmake_gtest REQUIRED)
   find_package(Boost REQUIRED COMPONENTS system)
@@ -110,6 +139,7 @@ if (BUILD_TESTING AND ("$ENV{ROS_DISTRO}" STRGREATER "galactic"))
   )
 
   ament_add_gtest(topic_service_test_server test/topic_service_test.cpp)
+  target_compile_features(topic_service_test_server PRIVATE cxx_std_17)
 
   # Humble and onwards
   if ("$ENV{ROS_DISTRO}" STRGREATER "galactic")
@@ -126,14 +156,16 @@ if (BUILD_TESTING AND ("$ENV{ROS_DISTRO}" STRGREATER "galactic"))
     )
   endif()
 
-  ament_target_dependencies(topic_service_test_server
-    rclcpp
-    marti_common_msgs
+  target_link_libraries(topic_service_test_server
+    ${rclcpp_LIBRARIES}
+    ${marti_common_msgs_LIBRARIES}
   )
   target_include_directories(topic_service_test_server
     PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
+    ${rclcpp_INCLUDE_DIRS}
+    ${marti_common_msgs_INCLUDE_DIRS}
   )
 
   ament_export_dependencies(rosidl_default_runtime)
@@ -154,14 +186,5 @@ install(DIRECTORY include/
 install(DIRECTORY launch/
   DESTINATION launch
 )
-
-ament_export_dependencies(ament_cmake)
-ament_export_dependencies(diagnostic_updater)
-ament_export_dependencies(marti_common_msgs)
-ament_export_dependencies(nav_msgs)
-ament_export_dependencies(rclcpp)
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(std_srvs)
-ament_export_include_directories(include)
 
 ament_package(CONFIG_EXTRAS cmake/swri_roscpp-extras.cmake )

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -23,7 +23,7 @@
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>gps_msgs</depend>
-  <depend>libgeos++-dev</depend>
+  <depend>libgeos-dev</depend>
   <depend>marti_nav_msgs</depend>
   <depend>proj</depend>
   <depend>rclcpp_components</depend>

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -23,7 +23,7 @@
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>gps_msgs</depend>
-  <depend>libgeos-dev</depend>
+  <depend>geos</depend>
   <depend>marti_nav_msgs</depend>
   <depend>proj</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
`swri_roscpp` is not exporting its dependencies correctly, as reported in https://github.com/swri-robotics/marti_common/issues/703. This appears to be caused by ament() macros not understanding what an INTERFACE library is. This PR replaces a lot of the ament() calls with direct CMake calls so that dependencies are correctly exported and linked.