### PR TITLE
Add ROS Environment Dependency

### DIFF
--- a/swri_roscpp/package.xml
+++ b/swri_roscpp/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>rosidl_cmake</build_depend>
+  <build_depend>ros_environment</build_depend>
 
   <depend>boost</depend>
   <depend>diagnostic_updater</depend>


### PR DESCRIPTION
Adding `ros_environment` as a build dependency to see if it fixes ROS build farm issues.