### PR TITLE
Add python3-natsort as Dependency

### DIFF
--- a/swri_cli_tools/package.xml
+++ b/swri_cli_tools/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>marti_introspection_msgs</depend>
+  <depend>python3-natsort</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
`swri_cli_tools` uses natsort, but it is not listed as a dependency in the package.xml.