### PR TITLE
Fix Iron CvBridge Warnings

### DIFF
--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -54,6 +54,12 @@ target_link_libraries(${PROJECT_NAME}
   opencv_core
   opencv_stitching
 )
+
+# Iron and later switched some cv_bridge files to .hpp from .h
+if ("$ENV{ROS_DISTRO}" STRLESS "iron")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE "-DUSE_CVBRIDGE_H_FILES")
+endif()
+
 ament_target_dependencies(${PROJECT_NAME}
   camera_calibration_parsers
   cv_bridge

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -55,11 +55,6 @@ target_link_libraries(${PROJECT_NAME}
   opencv_stitching
 )
 
-# Iron and later switched some cv_bridge files to .hpp from .h
-if ("$ENV{ROS_DISTRO}" STRLESS "iron")
-  target_compile_definitions(${PROJECT_NAME} PRIVATE "-DUSE_CVBRIDGE_H_FILES")
-endif()
-
 ament_target_dependencies(${PROJECT_NAME}
   camera_calibration_parsers
   cv_bridge
@@ -112,6 +107,11 @@ target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
 ament_target_dependencies(${PROJECT_NAME}_nodes
   ament_index_cpp
 )
+
+# Iron and later switched some cv_bridge files to .hpp from .h
+if ("$ENV{ROS_DISTRO}" STRLESS "iron")
+  target_compile_definitions(${PROJECT_NAME}_nodes PRIVATE "-DUSE_CVBRIDGE_H_FILES")
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/swri_image_util/src/nodes/blend_images_node.cpp
+++ b/swri_image_util/src/nodes/blend_images_node.cpp
@@ -30,7 +30,11 @@
 #include <opencv2/core/core.hpp>
 
 #include <rclcpp/rclcpp.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <message_filters/subscriber.h>
 #include <message_filters/time_synchronizer.h>

--- a/swri_image_util/src/nodes/contrast_stretch_node.cpp
+++ b/swri_image_util/src/nodes/contrast_stretch_node.cpp
@@ -36,7 +36,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <swri_image_util/image_normalization.h>
 
 #include <swri_math_util/math_util.h>

--- a/swri_image_util/src/nodes/crosshairs_node.cpp
+++ b/swri_image_util/src/nodes/crosshairs_node.cpp
@@ -36,7 +36,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/nodes/draw_polygon_node.cpp
+++ b/swri_image_util/src/nodes/draw_polygon_node.cpp
@@ -29,7 +29,11 @@
 
 #include <string>
 
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <opencv2/core/core.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/swri_image_util/src/nodes/draw_text_node.cpp
+++ b/swri_image_util/src/nodes/draw_text_node.cpp
@@ -35,7 +35,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <swri_math_util/math_util.h>
 
 namespace swri_image_util

--- a/swri_image_util/src/nodes/image_pub_node.cpp
+++ b/swri_image_util/src/nodes/image_pub_node.cpp
@@ -31,7 +31,11 @@
 
 #include <boost/make_shared.hpp>
 
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <image_transport/publisher.hpp>
 #include <image_transport/subscriber.hpp>

--- a/swri_image_util/src/nodes/normalization_image_node.cpp
+++ b/swri_image_util/src/nodes/normalization_image_node.cpp
@@ -34,7 +34,11 @@
 #include <ament_index_cpp/get_package_prefix.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 
 // OpenCV Libraries
 #include <opencv2/core/core.hpp>

--- a/swri_image_util/src/nodes/normalize_response_node.cpp
+++ b/swri_image_util/src/nodes/normalize_response_node.cpp
@@ -35,7 +35,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <swri_image_util/image_normalization.h>
 
 #include <swri_math_util/math_util.h>

--- a/swri_image_util/src/nodes/replace_colors_node.cpp
+++ b/swri_image_util/src/nodes/replace_colors_node.cpp
@@ -30,7 +30,11 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.h>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <sensor_msgs/msg/image.hpp>
 #include <swri_image_util/replace_colors.h>
 

--- a/swri_image_util/src/nodes/rotate_image_node.cpp
+++ b/swri_image_util/src/nodes/rotate_image_node.cpp
@@ -34,7 +34,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 
 #include <swri_math_util/math_util.h>
 

--- a/swri_image_util/src/nodes/scale_image_node.cpp
+++ b/swri_image_util/src/nodes/scale_image_node.cpp
@@ -35,7 +35,11 @@
 #include <rclcpp/rclcpp.hpp>
 #include <image_transport/image_transport.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <swri_math_util/math_util.h>
 
 namespace swri_image_util

--- a/swri_image_util/src/nodes/warp_image_node.cpp
+++ b/swri_image_util/src/nodes/warp_image_node.cpp
@@ -28,7 +28,11 @@
 // *****************************************************************************
 
 #include <algorithm>
+#ifdef USE_CVBRIDGE_H_FILES
 #include <cv_bridge/cv_bridge.h>
+#else
+#include <cv_bridge/cv_bridge.hpp>
+#endif
 #include <image_transport/image_transport.hpp>
 #include <image_transport/publisher.hpp>
 #include <image_transport/subscriber.hpp>


### PR DESCRIPTION
Iron changed the extension of a cv_bridge header file from .h to .hpp. This PR conditionally pulls in the correct header file based on the distribution.