### PR TITLE
Use System QoS Settings as Defaults

### DIFF
--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -116,7 +116,7 @@ class Subscriber
   Subscriber(rclcpp::Node &nh,
              const std::string &topic,
              std::shared_ptr< M const > *dest,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(1
               rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
   
   Subscriber& operator=(const Subscriber &other);
@@ -194,7 +194,7 @@ class Subscriber
     DIAG_LATENCY    = 1 << 3,  // Include latency information
     DIAG_RATE       = 1 << 4,  // Include rate information
 
-    DIAG_ALL        = a0,       // Abbreviation to include all information
+    DIAG_ALL        = ~0,       // Abbreviation to include all information
     DIAG_MOST       = DIAG_ALL ^ DIAG_CONNECTION
     // Abbreviation to include everything except connection info.
   };

--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -29,7 +29,6 @@
 #ifndef SWRI_ROSCPP_SUBSCRIBER_H_
 #define SWRI_ROSCPP_SUBSCRIBER_H_
 
-
 #include <rclcpp/rclcpp.hpp>
 #include <diagnostic_updater/diagnostic_status_wrapper.hpp>
 
@@ -77,7 +76,8 @@ class Subscriber
              uint32_t queue_size,
              void(T::*fp)(const std::shared_ptr< M const > &),
              T *obj,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
 
   // Using a standard function callback.
   template<class M>
@@ -85,7 +85,8 @@ class Subscriber
              const std::string &topic,
              uint32_t queue_size,
              const std::function<void(const std::shared_ptr<M const> &)> &callback,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
   
   // Versions of the previous functions, but with unique pointers for the
   // message instead of shared pointers
@@ -95,14 +96,16 @@ class Subscriber
              uint32_t queue_size,
              void(T::*fp)(const std::unique_ptr< M const > &),
              T *obj,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
 
   template<class M>
   Subscriber(rclcpp::Node &nh,
              const std::string &topic,
              uint32_t queue_size,
              const std::function<void(const std::unique_ptr<M const> &)> &callback,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
 
   // This is an alternate interface that stores a received message in
   // a variable without calling a user-defined callback function.

--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -116,7 +116,7 @@ class Subscriber
   Subscriber(rclcpp::Node &nh,
              const std::string &topic,
              std::shared_ptr< M const > *dest,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
               rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
   
   Subscriber& operator=(const Subscriber &other);

--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -116,7 +116,8 @@ class Subscriber
   Subscriber(rclcpp::Node &nh,
              const std::string &topic,
              std::shared_ptr< M const > *dest,
-             const rclcpp::QoS& transport_hints = rclcpp::QoS(1));
+             const rclcpp::QoS& transport_hints = rclcpp::QoS(
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
   
   Subscriber& operator=(const Subscriber &other);
 
@@ -193,7 +194,7 @@ class Subscriber
     DIAG_LATENCY    = 1 << 3,  // Include latency information
     DIAG_RATE       = 1 << 4,  // Include rate information
 
-    DIAG_ALL        = ~0,       // Abbreviation to include all information
+    DIAG_ALL        = a0,       // Abbreviation to include all information
     DIAG_MOST       = DIAG_ALL ^ DIAG_CONNECTION
     // Abbreviation to include everything except connection info.
   };


### PR DESCRIPTION
Changes the subscriber defaults from using an arbitrary depth of 1 to the system's RMW QoS defaults.