### PR TITLE
Add publisher and subscription options to ROS 2 swri_roscpp pub / sub constructors

### DIFF
--- a/swri_roscpp/include/swri_roscpp/publisher.h
+++ b/swri_roscpp/include/swri_roscpp/publisher.h
@@ -38,7 +38,8 @@ namespace swri
       rclcpp::Node &nh,
       const std::string name,
       uint32_t queue_size,
-      bool latched=false)
+      bool latched=false,
+      rclcpp::PublisherOptions pub_options=rclcpp::PublisherOptions())
   {
     RCLCPP_INFO(nh.get_logger(), "Publishing [%s].",
                 name.c_str());
@@ -47,7 +48,7 @@ namespace swri
     {
       qos = qos.transient_local();
     }
-    return nh.create_publisher<M>(name, qos);
+    return nh.create_publisher<M>(name, qos, pub_options);
   }
 }  // namespace swri
 #endif  // SWRI_ROSCPP_PUBLISHER_H_

--- a/swri_roscpp/include/swri_roscpp/subscriber.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber.h
@@ -77,7 +77,8 @@ class Subscriber
              void(T::*fp)(const std::shared_ptr< M const > &),
              T *obj,
              const rclcpp::QoS& transport_hints = rclcpp::QoS(
-              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)),
+             const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions());
 
   // Using a standard function callback.
   template<class M>
@@ -86,8 +87,9 @@ class Subscriber
              uint32_t queue_size,
              const std::function<void(const std::shared_ptr<M const> &)> &callback,
              const rclcpp::QoS& transport_hints = rclcpp::QoS(
-              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
-  
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)),
+             const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions());
+
   // Versions of the previous functions, but with unique pointers for the
   // message instead of shared pointers
   template<class M , class T >
@@ -97,7 +99,8 @@ class Subscriber
              void(T::*fp)(const std::unique_ptr< M const > &),
              T *obj,
              const rclcpp::QoS& transport_hints = rclcpp::QoS(
-              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)),
+             const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions());
 
   template<class M>
   Subscriber(rclcpp::Node &nh,
@@ -105,7 +108,8 @@ class Subscriber
              uint32_t queue_size,
              const std::function<void(const std::unique_ptr<M const> &)> &callback,
              const rclcpp::QoS& transport_hints = rclcpp::QoS(
-              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)),
+             const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions());
 
   // This is an alternate interface that stores a received message in
   // a variable without calling a user-defined callback function.
@@ -117,8 +121,9 @@ class Subscriber
              const std::string &topic,
              std::shared_ptr< M const > *dest,
              const rclcpp::QoS& transport_hints = rclcpp::QoS(
-              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)));
-  
+              rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)),
+             const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions());
+
   Subscriber& operator=(const Subscriber &other);
 
   // Reset all statistics, including message and timeout counts.
@@ -164,7 +169,7 @@ class Subscriber
   // Provide a negative value to disable the timeout (default is -1).
   void setTimeout(const rclcpp::Duration &time_out);
   void setTimeout(const double time_out);
-  
+
   // Block/unblock timeouts from occuring.  This allows you to
   // temporarily block timeouts (for example, if a message is not
   // expected in a particular mode).  Returns the current state
@@ -229,11 +234,12 @@ Subscriber::Subscriber(rclcpp::Node &nh,
                        uint32_t queue_size,
                        void(T::*fp)(const std::shared_ptr< M const > &),
                        T *obj,
-                       const rclcpp::QoS& transport_hints)
+                       const rclcpp::QoS& transport_hints,
+                       const rclcpp::SubscriptionOptions sub_options)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new TypedSubscriberImpl<M,T>(
-      nh, topic, queue_size, fp, obj, transport_hints));
+      nh, topic, queue_size, fp, obj, transport_hints, sub_options));
 }
 
 template<class M>
@@ -242,11 +248,12 @@ Subscriber::Subscriber(rclcpp::Node &nh,
                        const std::string &topic,
                        uint32_t queue_size,
                        const std::function<void(const std::shared_ptr<M const> &)> &callback,
-                       const rclcpp::QoS& transport_hints)
+                       const rclcpp::QoS& transport_hints,
+                       const rclcpp::SubscriptionOptions sub_options)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new BindSubscriberImpl<M>(
-      nh, topic, queue_size, callback, transport_hints));
+      nh, topic, queue_size, callback, transport_hints, sub_options));
 }
 
 template<class M>
@@ -254,11 +261,12 @@ inline
 Subscriber::Subscriber(rclcpp::Node &nh,
                        const std::string &topic,
                        std::shared_ptr< M const > *dest,
-                       const rclcpp::QoS& transport_hints)
+                       const rclcpp::QoS& transport_hints,
+                       const rclcpp::SubscriptionOptions sub_options)
 {
   impl_ = std::shared_ptr<SubscriberImpl>(
     new StorageSubscriberImpl<M>(
-      nh, topic, dest, transport_hints));
+      nh, topic, dest, transport_hints, sub_options));
 }
 
 inline

--- a/swri_roscpp/include/swri_roscpp/subscriber_impl.h
+++ b/swri_roscpp/include/swri_roscpp/subscriber_impl.h
@@ -311,7 +311,8 @@ namespace swri
         uint32_t queue_size,
         void(T::*fp)(const std::shared_ptr<const M> &),
         T *obj,
-        const rclcpp::QoS& transport_hints)
+        const rclcpp::QoS& transport_hints,
+        const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions())
     {
       unmapped_topic_ = topic;
       // mapped_topic_ = nh->ResolveName(topic);
@@ -330,7 +331,8 @@ namespace swri
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
                                          hints,
                                          std::bind(&TypedSubscriberImpl::handleMessage<const M>,
-                                                   this, std::placeholders::_1)
+                                                   this, std::placeholders::_1),
+                                         sub_options
                                          );
     }
 
@@ -365,7 +367,8 @@ namespace swri
         const std::string &topic,
         uint32_t queue_size,
         const std::function<void(const std::shared_ptr<const M>)> &callback,
-        const rclcpp::QoS& transport_hints)
+        const rclcpp::QoS& transport_hints,
+        const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions())
     {
       unmapped_topic_ = topic;
       //mapped_topic_ = nh->ResolveName(topic);
@@ -380,7 +383,8 @@ namespace swri
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
                                          hints,
                                          std::bind(&BindSubscriberImpl::handleMessage<M>,
-                                                   this, std::placeholders::_1)
+                                                   this, std::placeholders::_1),
+                                         sub_options
                                         );
     }
 
@@ -413,7 +417,8 @@ namespace swri
         rclcpp::Node& nh,
         const std::string &topic,
         std::shared_ptr< const M > *dest,
-        const rclcpp::QoS& transport_hints)
+        const rclcpp::QoS& transport_hints,
+        const rclcpp::SubscriptionOptions sub_options = rclcpp::SubscriptionOptions())
     {
       unmapped_topic_ = topic;
       //mapped_topic_ = nh->ResolveName(topic);
@@ -425,7 +430,8 @@ namespace swri
       sub_ = nh_->create_subscription<M>(unmapped_topic_,
                                          transport_hints,
                                          std::bind(&StorageSubscriberImpl::handleMessage<M>,
-                                                   this, std::placeholders::_1)
+                                                   this, std::placeholders::_1),
+                                         sub_options
                                          );
     }
 


### PR DESCRIPTION
With this change, someone using `swri_roscpp`'s publishers or subscribers will be able to put subscriptions into a non-default callback group or turn on intraprocess communications at the pub/sub level, along with some other configuration features.

I currently have the `SubscriptionOptions` as the last argument, but if we think that argument is more likely to be used / required than the transport hints / QoS, then I can flip them.