### PR TITLE
Fixing Wrapping Latitude and Longitude Wrapping Calculations

### DIFF
--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -250,11 +250,23 @@ namespace swri_transform_util
       double rlat = latitude * swri_math_util::_deg_2_rad;
       double rlon = longitude * swri_math_util::_deg_2_rad;
       double dLat = (rlat - reference_latitude_) * rho_lat_;
-      double dLon = (rlon - reference_longitude_) * rho_lon_;
-
+      double dLon = (rlon - reference_longitude_);
+      // Check for case where the shortest distance crosses the antimeridian
+      if (dLon > swri_math_util::_pi)
+      {   
+        dLon -= swri_math_util::_2pi;
+      }   
+      
+      if (dLon < -swri_math_util::_pi)
+      {   
+        dLon += swri_math_util::_2pi;
+      }   
+        
+      dLon *= rho_lon_;
+  
       x =  cos_angle_ * dLon + sin_angle_ * dLat;
       y = -sin_angle_ * dLon + cos_angle_ * dLat;
-
+  
       return true;
     }
 
@@ -276,6 +288,16 @@ namespace swri_transform_util
 
       latitude = rlat * swri_math_util::_rad_2_deg;
       longitude = rlon * swri_math_util::_rad_2_deg;
+      // Constrain longitude in case it has wrapped across the date line
+      if (longitude >= 180.0)
+      {   
+        longitude -= 360.0;
+      }   
+        
+      if (longitude < -180.0)
+      {
+        longitude += 360.0;
+      }
     }
 
     return initialized_;

--- a/swri_transform_util/test/test_local_xy_util.cpp
+++ b/swri_transform_util/test/test_local_xy_util.cpp
@@ -92,6 +92,47 @@ TEST(LocalXyUtilTests, TestOffset2)
   EXPECT_FLOAT_EQ(y, y2);
 }
 
+
+TEST(LocalXyUtilTests, TestOffset3)
+{
+  // Set origin at dateline
+  swri_transform_util::LocalXyWgs84Util local_xy_util(0, -180);
+
+  double x = -100.0;
+  double y = 10.0;
+
+  // Offset is west, across the dateline
+  double lat, lon;
+  local_xy_util.ToWgs84(x, y, lat, lon);
+  EXPECT_NEAR(0.00009045, lat, 0.0000001);  // ~1cm accuracy
+  EXPECT_NEAR(179.9991017, lon, 0.0000001);
+
+  double x2, y2;
+  local_xy_util.ToLocalXy(lat, lon, x2, y2);
+  EXPECT_FLOAT_EQ(x, x2);
+  EXPECT_FLOAT_EQ(y, y2);
+}
+
+TEST(LocalXyUtilTests, TestOffset4)
+{
+  // Set origin just west of dateline
+  swri_transform_util::LocalXyWgs84Util local_xy_util(0, 179.9999);
+
+  double x = 100.0;
+  double y = -10.0;
+
+  // Offset is east, across the dateline
+  double lat, lon;
+  local_xy_util.ToWgs84(x, y, lat, lon);
+  EXPECT_NEAR(-0.00009045, lat, 0.0000001);  // ~1cm accuracy
+  EXPECT_NEAR(-179.9992017, lon, 0.0000001);
+
+  double x2, y2;
+  local_xy_util.ToLocalXy(lat, lon, x2, y2);
+  EXPECT_FLOAT_EQ(x, x2);
+  EXPECT_FLOAT_EQ(y, y2);
+}
+
 TEST(LocalXyUtilTests, LocalXyFromWgs84)
 {
   double x, y;


### PR DESCRIPTION
Port of this fix: https://github.com/swri-robotics/marti_common/issues/644