### PR TITLE
Fix UTM Utils and Get Tests to Build in ROS 2

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -161,20 +161,21 @@ if(BUILD_TESTING)
   target_link_libraries(transform_manager_test ${PROJECT_NAME})
   ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
 
-  # add_rostest_gtest(test_local_xy_util launch/local_xy_util.test test/test_local_xy_util.cpp)
-  # target_link_libraries(test_local_xy_util ${PROJECT_NAME})
+  ament_add_gtest(local_xy_util_test test/test_local_xy_util.cpp)
+  target_link_libraries(local_xy_util_test ${PROJECT_NAME})
+  ament_target_dependencies(local_xy_util_test rclcpp)
 
   ament_add_gtest(utm_util_test test/test_utm_util.cpp)
   target_link_libraries(utm_util_test ${PROJECT_NAME})
+  ament_target_dependencies(utm_util_test rclcpp)
 
-  # add_rostest_gtest(test_transform_manager launch/transform_manager.test test/test_transform_manager.cpp)
-  # target_link_libraries(test_transform_manager ${PROJECT_NAME})
+  ament_add_gtest(georeference_test test/test_georeference.cpp)
+  target_link_libraries(georeference_test ${PROJECT_NAME})
+  ament_target_dependencies(georeference_test rclcpp tf2 ament_index_cpp)
 
-  # add_rostest_gtest(test_georeference launch/georeference.test test/test_georeference.cpp)
-  # target_link_libraries(test_georeference ${PROJECT_NAME})
-
-  # add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
-  # target_link_libraries(test_transform_util ${PROJECT_NAME})
+  ament_add_gtest(transform_util_test test/test_transform_util.cpp)
+  target_link_libraries(transform_util_test ${PROJECT_NAME})
+  ament_target_dependencies(transform_util_test rclcpp tf2)
 
   # add_rostest(test/initialize_invalid_gps.test)
   # add_rostest(test/initialize_invalid_navsat.test)
@@ -183,10 +184,19 @@ if(BUILD_TESTING)
   # add_rostest(test/initialize_origin_auto_navsat.test)
   # add_rostest(test/initialize_origin_manual.test)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/local_xy_util.test.py)
 
   install(TARGETS
     transform_manager_test
+    utm_util_test
+    georeference_test
+    transform_util_test
+    local_xy_util_test
     DESTINATION lib/${PROJECT_NAME}
+  )
+
+  install(DIRECTORY test/data
+    DESTINATION share/${PROJECT_NAME}
   )
 
 endif()

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -150,10 +150,20 @@ target_include_directories(lat_lon_tf_echo
 
 target_link_libraries(lat_lon_tf_echo ${PROJECT_NAME})
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(utm_util_test test/test_utm_util)
+  target_link_libraries(utm_util_test ${PROJECT_NAME})
+  install(
+    TARGETS utm_util_test
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
+
 # TODO pjr Convert unit tests
 # if(BUILD_TESTING)
 #   find_package(ament_cmake_gtest REQUIRED)
-# 
+#
 #  add_rostest_gtest(test_local_xy_util launch/local_xy_util.test test/test_local_xy_util.cpp)
 #  target_link_libraries(test_local_xy_util ${PROJECT_NAME})
 #

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -177,14 +177,14 @@ if(BUILD_TESTING)
   target_link_libraries(transform_util_test ${PROJECT_NAME})
   ament_target_dependencies(transform_util_test rclcpp tf2)
 
-  # add_rostest(test/initialize_invalid_gps.test)
-  # add_rostest(test/initialize_invalid_navsat.test)
-  # add_rostest(test/initialize_origin_auto_custom.test)
-  # add_rostest(test/initialize_origin_auto_gps.test)
-  # add_rostest(test/initialize_origin_auto_navsat.test)
-  # add_rostest(test/initialize_origin_manual.test)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/local_xy_util.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_invalid_gps.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_invalid_navsat.test.py)
+  # The "custom" functionality appears to be gone in ROS 2.
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_origin_auto_gps.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_origin_auto_navsat.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_origin_manual.test.py)
 
   install(TARGETS
     transform_manager_test
@@ -195,7 +195,7 @@ if(BUILD_TESTING)
     DESTINATION lib/${PROJECT_NAME}
   )
 
-  install(DIRECTORY test/data
+  install(DIRECTORY test
     DESTINATION share/${PROJECT_NAME}
   )
 

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -152,40 +152,45 @@ target_link_libraries(lat_lon_tf_echo ${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  ament_add_gtest(utm_util_test test/test_utm_util)
+  find_package(launch_testing_ament_cmake)
+
+  # ament_add_gtest_executable(transform_manager_test test/test_transform_manager.cpp)
+  # target_include_directories(transform_manager_test PRIVATE
+  #   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  # )
+  # target_link_libraries(transform_manager_test ${PROJECT_NAME})
+  # ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
+
+  # add_rostest_gtest(test_local_xy_util launch/local_xy_util.test test/test_local_xy_util.cpp)
+  # target_link_libraries(test_local_xy_util ${PROJECT_NAME})
+
+  ament_add_gtest(utm_util_test test/test_utm_util.cpp)
   target_link_libraries(utm_util_test ${PROJECT_NAME})
-  install(
-    TARGETS utm_util_test
+
+  # add_rostest_gtest(test_transform_manager launch/transform_manager.test test/test_transform_manager.cpp)
+  # target_link_libraries(test_transform_manager ${PROJECT_NAME})
+
+  # add_rostest_gtest(test_georeference launch/georeference.test test/test_georeference.cpp)
+  # target_link_libraries(test_georeference ${PROJECT_NAME})
+
+  # add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
+  # target_link_libraries(test_transform_util ${PROJECT_NAME})
+
+  # add_rostest(test/initialize_invalid_gps.test)
+  # add_rostest(test/initialize_invalid_navsat.test)
+  # add_rostest(test/initialize_origin_auto_custom.test)
+  # add_rostest(test/initialize_origin_auto_gps.test)
+  # add_rostest(test/initialize_origin_auto_navsat.test)
+  # add_rostest(test/initialize_origin_manual.test)
+  # add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
+
+  install(TARGETS
+    # transform_manager_test
+    utm_util_test
     DESTINATION lib/${PROJECT_NAME}
   )
-endif()
 
-# TODO pjr Convert unit tests
-# if(BUILD_TESTING)
-#   find_package(ament_cmake_gtest REQUIRED)
-#
-#  add_rostest_gtest(test_local_xy_util launch/local_xy_util.test test/test_local_xy_util.cpp)
-#  target_link_libraries(test_local_xy_util ${PROJECT_NAME})
-#
-#  add_rostest_gtest(test_utm_util launch/utm_util.test test/test_utm_util.cpp)
-#  target_link_libraries(test_utm_util ${PROJECT_NAME})
-#
-#  add_rostest_gtest(test_transform_manager launch/transform_manager.test test/test_transform_manager.cpp)
-#  target_link_libraries(test_transform_manager ${PROJECT_NAME})
-#
-#  add_rostest_gtest(test_georeference launch/georeference.test test/test_georeference.cpp)
-#  target_link_libraries(test_georeference ${PROJECT_NAME})
-#
-#  add_rostest_gtest(test_transform_util launch/transform_util.test test/test_transform_util.cpp)
-#  target_link_libraries(test_transform_util ${PROJECT_NAME})
-#
-#  add_rostest(test/initialize_invalid_gps.test)
-#  add_rostest(test/initialize_invalid_navsat.test)
-#  add_rostest(test/initialize_origin_auto_custom.test)
-#  add_rostest(test/initialize_origin_auto_gps.test)
-#  add_rostest(test/initialize_origin_auto_navsat.test)
-#  add_rostest(test/initialize_origin_manual.test)
-# endif()
+endif()
 
 install(DIRECTORY include/
   DESTINATION include

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -154,12 +154,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(launch_testing_ament_cmake)
 
-  # ament_add_gtest_executable(transform_manager_test test/test_transform_manager.cpp)
-  # target_include_directories(transform_manager_test PRIVATE
-  #   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  # )
-  # target_link_libraries(transform_manager_test ${PROJECT_NAME})
-  # ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
+  ament_add_gtest_executable(transform_manager_test test/test_transform_manager.cpp)
+  target_include_directories(transform_manager_test PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  )
+  target_link_libraries(transform_manager_test ${PROJECT_NAME})
+  ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
 
   # add_rostest_gtest(test_local_xy_util launch/local_xy_util.test test/test_local_xy_util.cpp)
   # target_link_libraries(test_local_xy_util ${PROJECT_NAME})
@@ -182,11 +182,10 @@ if(BUILD_TESTING)
   # add_rostest(test/initialize_origin_auto_gps.test)
   # add_rostest(test/initialize_origin_auto_navsat.test)
   # add_rostest(test/initialize_origin_manual.test)
-  # add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
 
   install(TARGETS
-    # transform_manager_test
-    utm_util_test
+    transform_manager_test
     DESTINATION lib/${PROJECT_NAME}
   )
 

--- a/swri_transform_util/launch/local_xy_util.test.py
+++ b/swri_transform_util/launch/local_xy_util.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# *****************************************************************************
+#
+# Copyright (c) 2024, Southwest Research Institute® (SwRI®)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# *****************************************************************************
+
+import os
+import unittest
+import pytest
+
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "lib/swri_transform_util",
+            "local_xy_util_test",
+    )
+
+    return launch_testing.actions.GTest(
+            path=[test_path],
+            name="local_xy_util_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="initialize_origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+            "local_xy_origin": "swri",
+            "local_xy_origins": [29.45196669, -98.61370577, 233.719, 0.0],
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class LocalXyUtilTest(unittest.TestCase):
+    def test_local_xy_util(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/launch/transform_manager.test.py
+++ b/swri_transform_util/launch/transform_manager.test.py
@@ -65,7 +65,6 @@ def generate_test_description():
         }]
     )
 
-    # TODO static transform publisher tf1
     tf1 = Node(
         package="tf2_ros",
         name="tf1",
@@ -80,13 +79,41 @@ def generate_test_description():
             "--frame-id", "far_field",
             "--child-frame-id", "near_field"],
     )
-    # TODO static transform publisher tf2
-    # TODO static transform publisher tf3
+    tf2 = Node(
+        package="tf2_ros",
+        name="tf2",
+        executable="static_transform_publisher",
+        arguments=[
+            "--x", "1000.0",
+            "--y", "0.0",
+            "--z", "0.0",
+            "--roll", "0.0",
+            "--pitch", "0.0",
+            "--yaw", "0.0",
+            "--frame-id", "far_field",
+            "--child-frame-id", "veh_far_field"],
+    )
+    tf3 = Node(
+        package="tf2_ros",
+        name="tf3",
+        executable="static_transform_publisher",
+        arguments=[
+            "--x", "0.0",
+            "--y", "0.0",
+            "--z", "0.0",
+            "--roll", "0.0",
+            "--pitch", "0.0",
+            "--yaw", "0.0",
+            "--frame-id", "veh_far_field",
+            "--child-frame-id", "veh_near_field"],
+    )
 
     return launch.LaunchDescription(
             [
                 init_origin,
                 tf1,
+                tf2,
+                tf3,
                 launch_testing.util.KeepAliveProc(),
                 launch_testing.actions.ReadyToTest(),
             ]

--- a/swri_transform_util/launch/transform_manager.test.py
+++ b/swri_transform_util/launch/transform_manager.test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# *****************************************************************************
+#
+# Copyright (c) 2024, Southwest Research Institute® (SwRI®)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# *****************************************************************************
+
+import os
+import unittest
+import pytest
+
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "lib/swri_transform_util",
+            "transform_manager_test",
+    )
+
+    return launch_testing.actions.GTest(
+            path=[test_path],
+            name="transform_manager_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="initialize_origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+            "local_xy_origin": "swri",
+            "local_xy_origins": [29.45196669, -98.61370577, 233.719, 0.0],
+        }]
+    )
+
+    # TODO static transform publisher tf1
+    tf1 = Node(
+        package="tf2_ros",
+        name="tf1",
+        executable="static_transform_publisher",
+        arguments=[
+            "--x", "500.0",
+            "--y", "500.0",
+            "--z", "0.0",
+            "--roll", "0.0",
+            "--pitch", "0.0",
+            "--yaw", "0.0",
+            "--frame_id", "/far_field",
+            "--child_frame_id", "/near_field"],
+    )
+    # TODO static transform publisher tf2
+    # TODO static transform publisher tf3
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                tf1,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class TransformManagerTest(unittest.TestCase):
+    def test_transform_manager(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/launch/transform_manager.test.py
+++ b/swri_transform_util/launch/transform_manager.test.py
@@ -73,12 +73,12 @@ def generate_test_description():
         arguments=[
             "--x", "500.0",
             "--y", "500.0",
-            "--z", "0.0",
-            "--roll", "0.0",
-            "--pitch", "0.0",
-            "--yaw", "0.0",
-            "--frame_id", "/far_field",
-            "--child_frame_id", "/near_field"],
+            "--z", "0",
+            "--roll", "0",
+            "--pitch", "0",
+            "--yaw", "0",
+            "--frame-id", "far_field",
+            "--child-frame-id", "near_field"],
     )
     # TODO static transform publisher tf2
     # TODO static transform publisher tf3

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -39,9 +39,13 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
-  <test_depend>ament_cmake_gtest</test_depend>
 
   <exec_depend>python3-numpy</exec_depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -47,6 +47,8 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>tf_transformations</test_depend>
+  <test_depend>python-transforms3d-pip</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -43,6 +43,7 @@
   <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -39,6 +39,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml-cpp</depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <exec_depend>python3-numpy</exec_depend>
 

--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -32,6 +32,7 @@
 #include <functional>
 
 #include <tf2/utils.h>
+#include <rcutils/logging_macros.h>
 
 #include <swri_math_util/constants.h>
 #include <swri_math_util/trig_util.h>
@@ -209,7 +210,7 @@ namespace swri_transform_util
       }
 
       frame_ = frame;
-
+      RCUTILS_LOG_WARN("LocalXyWgs84Util initializing origin to lat: %f, lon: %f, alt: %f", latitude, longitude, reference_altitude_);
       Initialize();
       pose_sub_.reset();
       return;

--- a/swri_transform_util/src/utm_util.cpp
+++ b/swri_transform_util/src/utm_util.cpp
@@ -121,12 +121,10 @@ namespace swri_transform_util
     zone = GetZone(longitude);
     band = GetBand(latitude);
 
-    double x = longitude * swri_math_util::_deg_2_rad;
-    double y = latitude * swri_math_util::_deg_2_rad;
-
     // Get easting and northing values.
     PJ_COORD c, c_out;
-    c = proj_coord(x, y, 0, 0);
+    c.lp.lam = longitude;
+    c.lp.phi = latitude;
 
     // Get easting and northing values.
     if (band <= 'N')
@@ -164,11 +162,9 @@ namespace swri_transform_util
   {
     boost::unique_lock<boost::mutex> lock(mutex_);
 
-    double x = easting;
-    double y = northing;
-
     PJ_COORD c, c_out;
-    c = proj_coord(easting, northing, 0, 0);
+    c.enu.e = easting;
+    c.enu.n = northing;
 
     if (band <= 'N')
     {
@@ -179,8 +175,8 @@ namespace swri_transform_util
       c_out = proj_trans(P_ll_north_[zone - 1], PJ_INV, c);
     }
 
-    longitude = c_out.xyz.x * swri_math_util::_rad_2_deg;
-    latitude = c_out.xyz.y * swri_math_util::_rad_2_deg;
+    longitude = c_out.lp.lam;
+    latitude = c_out.lp.phi;
   }
 
   UtmUtil::UtmUtil() :

--- a/swri_transform_util/src/utm_util.cpp
+++ b/swri_transform_util/src/utm_util.cpp
@@ -86,12 +86,12 @@ namespace swri_transform_util
     for (int i = 0; i < 60; i++)
     {
       snprintf(args, sizeof(args), "+proj=utm +ellps=WGS84 +zone=%d", i + 1);
-      snprintf(args, sizeof(args), "+proj=utm +ellps=WGS84 +zone=%d +south", i + 1);
-
       P_ll_north_[i] = proj_create_crs_to_crs(PJ_DEFAULT_CTX,
                                "+proj=latlong +ellps=WGS84",
                                args,
                                NULL);
+
+      snprintf(args, sizeof(args), "+proj=utm +ellps=WGS84 +zone=%d +south", i + 1);
       P_ll_south_[i] = proj_create_crs_to_crs(PJ_DEFAULT_CTX,
                                "+proj=latlong +ellps=WGS84",
                                args,
@@ -176,7 +176,7 @@ namespace swri_transform_util
     }
     else
     {
-      c_out = proj_trans(P_ll_south_[zone - 1], PJ_INV, c);
+      c_out = proj_trans(P_ll_north_[zone - 1], PJ_INV, c);
     }
 
     longitude = c_out.xyz.x * swri_math_util::_rad_2_deg;

--- a/swri_transform_util/test/initialize_invalid_gps.test.py
+++ b/swri_transform_util/test/initialize_invalid_gps.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import pytest
+import unittest
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "share/swri_transform_util",
+            "test/test_initialize_origin.py"
+    )
+
+    return launch.actions.ExecuteProcess(
+            cmd=["python3", test_path, "invalid_gps"],
+            name="init_origin_invalid_gps_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class InvalidGPSTest(unittest.TestCase):
+    def test_invalid_gps(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/test/initialize_invalid_navsat.test.py
+++ b/swri_transform_util/test/initialize_invalid_navsat.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import pytest
+import unittest
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "share/swri_transform_util",
+            "test/test_initialize_origin.py"
+    )
+
+    return launch.actions.ExecuteProcess(
+            cmd=["python3", test_path, "invalid_navsat"],
+            name="init_origin_invalid_navsat_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class InvalidNavsatTest(unittest.TestCase):
+    def test_invalid_navsat(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/test/initialize_origin_auto_gps.test.py
+++ b/swri_transform_util/test/initialize_origin_auto_gps.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import pytest
+import unittest
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "share/swri_transform_util",
+            "test/test_initialize_origin.py"
+    )
+
+    return launch.actions.ExecuteProcess(
+            cmd=["python3", test_path, "auto_gps"],
+            name="init_origin_auto_gps_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class AutoGpsTest(unittest.TestCase):
+    def test_auto_gps(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/test/initialize_origin_auto_navsat.test.py
+++ b/swri_transform_util/test/initialize_origin_auto_navsat.test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import pytest
+import unittest
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "share/swri_transform_util",
+            "test/test_initialize_origin.py"
+    )
+
+    return launch.actions.ExecuteProcess(
+            cmd=["python3", test_path, "auto_navsat"],
+            name="init_origin_auto_gps_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class AutoNavSatTest(unittest.TestCase):
+    def test_auto_navsat(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/test/initialize_origin_manual.test.py
+++ b/swri_transform_util/test/initialize_origin_manual.test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2017, Southwest Research Institute (SwRI)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute (SwRI) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL SOUTHWEST RESEARCH INSTITUTE BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import pytest
+import unittest
+import launch
+import launch_ros
+import launch_testing
+import ament_index_python
+from launch_ros.actions import Node
+
+PKG = 'swri_transform_util'
+NAME = 'test_initialize_origin'
+
+ORIGIN_TOPIC = '/local_xy_origin'
+
+def get_tests(*, args=[]):
+    test_path = os.path.join(
+            ament_index_python.get_package_prefix("swri_transform_util"),
+            "share/swri_transform_util",
+            "test/test_initialize_origin.py"
+    )
+
+    return launch.actions.ExecuteProcess(
+            cmd=["python3", test_path, "manual"],
+            name="init_origin_auto_gps_test",
+            additional_env={"PYTHONBUFFERED": "1"},
+            output="screen",
+    )
+
+@pytest.mark.launch_test
+def generate_test_description():
+    init_origin = Node(
+        package="swri_transform_util",
+        name="origin",
+        executable="initialize_origin.py",
+        parameters=[{
+            "local_xy_frame": "/far_field",
+            "local_xy_origin": "swri",
+            "local_xy_origins": [29.45196669, -98.61370577, 233.719, 0.0],
+        }]
+    )
+
+    return launch.LaunchDescription(
+            [
+                init_origin,
+                launch_testing.util.KeepAliveProc(),
+                launch_testing.actions.ReadyToTest(),
+            ]
+    )
+
+class ManualTest(unittest.TestCase):
+    def test_manual(self, launch_service, proc_info, proc_output):
+        tests = get_tests();
+        with launch_testing.tools.launch_process(
+            launch_service, tests, proc_info, proc_output
+        ):
+            proc_info.assertWaitForStartup(process=tests, timeout=30)
+            proc_info.assertWaitForShutdown(process=tests, timeout=600)
+        launch_testing.asserts.assertExitCodes(proc_info, process=tests)

--- a/swri_transform_util/test/test_georeference.cpp
+++ b/swri_transform_util/test/test_georeference.cpp
@@ -29,15 +29,15 @@
 
 #include <gtest/gtest.h>
 
-#include <ros/ros.h>
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <swri_transform_util/georeference.h>
 
 TEST(GeoreferenceTests, Load)
 {
-  std::string filename;
-  ASSERT_TRUE(ros::param::get("geo_file", filename));
-
+  std::string package = ament_index_cpp::get_package_share_directory("swri_transform_util");
+  std::string filename = package + "/data/test.geo";
   swri_transform_util::GeoReference georeference(filename);
   ASSERT_TRUE(georeference.Load());
 
@@ -51,8 +51,8 @@ TEST(GeoreferenceTests, Load)
 
 TEST(GeoreferenceTests, LoadExtension)
 {
-  std::string filename;
-  ASSERT_TRUE(ros::param::get("geo_file_extension", filename));
+  std::string package = ament_index_cpp::get_package_share_directory("swri_transform_util");
+  std::string filename = package + "/data/test_extension.geo";
 
   swri_transform_util::GeoReference georeference(filename);
   ASSERT_TRUE(georeference.Load());
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize the ROS core parameters can be loaded from the launch file
-  ros::init(argc, argv, "test_georeference");
+  rclcpp::init(argc, argv);
 
   return RUN_ALL_TESTS();
 }

--- a/swri_transform_util/test/test_georeference.cpp
+++ b/swri_transform_util/test/test_georeference.cpp
@@ -37,7 +37,7 @@
 TEST(GeoreferenceTests, Load)
 {
   std::string package = ament_index_cpp::get_package_share_directory("swri_transform_util");
-  std::string filename = package + "/data/test.geo";
+  std::string filename = package + "/test/data/test.geo";
   swri_transform_util::GeoReference georeference(filename);
   ASSERT_TRUE(georeference.Load());
 
@@ -52,7 +52,7 @@ TEST(GeoreferenceTests, Load)
 TEST(GeoreferenceTests, LoadExtension)
 {
   std::string package = ament_index_cpp::get_package_share_directory("swri_transform_util");
-  std::string filename = package + "/data/test_extension.geo";
+  std::string filename = package + "/test/data/test_extension.geo";
 
   swri_transform_util::GeoReference georeference(filename);
   ASSERT_TRUE(georeference.Load());

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -272,18 +272,20 @@ class TestInvalidNavSatFix(TestInvalidOrigin):
         # See documentation in testInvalidGPSFix.
         timeout = time.time() + 2  # time out after 2 seconds, which should be plenty
         node_attached = False
+        count = 0
         while not self.got_message and time.time() < timeout:
             if not node_attached and nsf_pub.get_subscription_count() > 0:
                 node_attached = True
             if node_attached and nsf_pub.get_subscription_count() == 0:
                 break
+            count = nsf_pub.get_subscription_count()
             nsf_pub.publish(nsf_msg)
             rclpy.spin_once(self.node, timeout_sec=0.01)
             time.sleep(0.01)
 
         self.assertFalse(self.got_message,
                          "initialize_origin should not have published an origin.")
-        self.assertFalse(node_attached and nsf_pub.get_subscription_count() == 0,
+        self.assertFalse(node_attached and count == 0,
                          "initialize_origin unsubscribed without getting a valid fix.")
 
         self.node.destroy_node()

--- a/swri_transform_util/test/test_local_xy_util.cpp
+++ b/swri_transform_util/test/test_local_xy_util.cpp
@@ -29,7 +29,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <swri_transform_util/local_xy_util.h>
 
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize the ROS core parameters can be loaded from the launch file
-  ros::init(argc, argv, "test_local_xy_util");
+  rclcpp::init(argc, argv);
 
   return RUN_ALL_TESTS();
 }

--- a/swri_transform_util/test/test_transform_manager.cpp
+++ b/swri_transform_util/test/test_transform_manager.cpp
@@ -86,319 +86,319 @@ TEST_F(TransformManagerTests, Identity1)
   EXPECT_FLOAT_EQ(p1.y(), p3.y());
 }
 
-/* TEST_F(TransformManagerTests, IdentityNoSlash) */
-/* { */
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/near_field", */
-/*       "near_field", */
-/*       transform)); */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "near_field", */
-/*       "/near_field", */
-/*       transform)); */
-/* } */
-
-/* TEST_F(TransformManagerTests, Identity2) */
-/* { */
-/*   tf2::Vector3 p1(435, -900, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/some_frame", */
-/*       "/some_frame", */
-/*       transform)); */
-
-/*   tf2::Vector3 p2 = transform * p1; */
-
-/*   EXPECT_FLOAT_EQ(p1.x(), p2.x()); */
-/*   EXPECT_FLOAT_EQ(p1.y(), p2.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * p2; */
-/*   EXPECT_FLOAT_EQ(p1.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(p1.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToTf1) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 far_field(0, 0, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/near_field", */
-/*       "/far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 near_field = transform * far_field; */
-
-/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
-/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * near_field; */
-/*   EXPECT_FLOAT_EQ(far_field.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(far_field.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToTf1NoSlash) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 far_field(0, 0, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/near_field", */
-/*       "far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 near_field = transform * far_field; */
-
-/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
-/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * near_field; */
-/*   EXPECT_FLOAT_EQ(far_field.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(far_field.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToTf2) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 far_field(0, 0, 0); */
-
-/*   tf::StampedTransform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/near_field", */
-/*       "/far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 near_field = transform * far_field; */
-
-/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
-/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, WgsToUtm) */
-/* { */
-/*   // San Antonio International Airport */
-/*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_utm_frame, */
-/*       swri_transform_util::_wgs84_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 utm = transform * wgs84; */
-
-/*   EXPECT_FLOAT_EQ(551170, utm.x()); */
-/*   EXPECT_FLOAT_EQ(3266454, utm.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * utm; */
-/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, WgsToUtmNoSlash) */
-/* { */
-/*   // San Antonio International Airport */
-/*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "utm", */
-/*       "wgs84", */
-/*       transform)); */
-
-/*   tf2::Vector3 utm = transform * wgs84; */
-
-/*   EXPECT_FLOAT_EQ(551170, utm.x()); */
-/*   EXPECT_FLOAT_EQ(3266454, utm.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * utm; */
-/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, UtmToWgs84) */
-/* { */
-/*   // San Antonio International Airport */
-/*   tf2::Vector3 utm(551170, 3266454, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_wgs84_frame, */
-/*       swri_transform_util::_utm_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 wgs84 = transform * utm; */
-
-/*   EXPECT_FLOAT_EQ(29.526667, wgs84.y()); */
-/*   EXPECT_FLOAT_EQ(-98.471944, wgs84.x()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * wgs84; */
-/*   EXPECT_FLOAT_EQ(utm.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(utm.y(), p3.y()); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToUtm1) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 tf(0, 0, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_utm_frame, */
-/*       "/far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 utm = transform * tf; */
-
-/*   EXPECT_FLOAT_EQ(537460.3372816057, utm.x()); */
-/*   EXPECT_FLOAT_EQ(3258123.434110421, utm.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * utm; */
-/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToUtm1NoSlash) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 tf(0, 0, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "utm", */
-/*       "far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 utm = transform * tf; */
-
-/*   EXPECT_FLOAT_EQ(537460.3372816057, utm.x()); */
-/*   EXPECT_FLOAT_EQ(3258123.434110421, utm.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * utm; */
-/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, TfToUtm2) */
-/* { */
-/*   tf2::Vector3 tf(500, 500, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_utm_frame, */
-/*       "/far_field", */
-/*       transform)); */
-
-/*   tf2::Vector3 utm = transform * tf; */
-
-/*   EXPECT_NEAR(537460.3372816057 + 500.0, utm.x(), 1.9); */
-/*   EXPECT_NEAR(3258123.434110421 + 500.0, utm.y(), 1.5); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * utm; */
-/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, UtmToTf1) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/far_field", */
-/*       swri_transform_util::_utm_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 tf = transform * utm; */
-
-/*   EXPECT_NEAR(0, tf.x(), 0.0005); */
-/*   EXPECT_NEAR(0, tf.y(), 0.0005); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, UtmToTf2) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/near_field", */
-/*       swri_transform_util::_utm_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 tf = transform * utm; */
-
-/*   EXPECT_NEAR(-500, tf.x(), 0.0005); */
-/*   EXPECT_NEAR(-500, tf.y(), 0.0005); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, UtmToTf3) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 utm(537460.3372816057 - 500, 3258123.434110421 - 500, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/far_field", */
-/*       swri_transform_util::_utm_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 tf = transform * utm; */
-
-/*   EXPECT_NEAR(-500, tf.x(), 1.9); */
-/*   EXPECT_NEAR(-500, tf.y(), 1.5); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
-/* } */
-
-/* TEST_F(TransformManagerTests, UtmToTf4) */
-/* { */
-/*   // San Antonio International Airport */
-/*   tf2::Vector3 utm(551170, 3266454, 0); */
-
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "/far_field", */
-/*       swri_transform_util::_utm_frame, */
-/*       transform)); */
-
-/*   tf2::Vector3 tf = transform * utm; */
-
-/*   EXPECT_FLOAT_EQ(13752.988, tf.x()); */
-/*   EXPECT_FLOAT_EQ(8280.0176, tf.y()); */
-
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
-/* } */
+TEST_F(TransformManagerTests, IdentityNoSlash)
+{
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      "near_field",
+      transform));
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "near_field",
+      "/near_field",
+      transform));
+}
+
+TEST_F(TransformManagerTests, Identity2)
+{
+  tf2::Vector3 p1(435, -900, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/some_frame",
+      "/some_frame",
+      transform));
+
+  tf2::Vector3 p2 = transform * p1;
+
+  EXPECT_FLOAT_EQ(p1.x(), p2.x());
+  EXPECT_FLOAT_EQ(p1.y(), p2.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * p2;
+  EXPECT_FLOAT_EQ(p1.x(), p3.x());
+  EXPECT_FLOAT_EQ(p1.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, TfToTf1)
+{
+  // Local Origin
+  tf2::Vector3 far_field(0, 0, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      "/far_field",
+      transform));
+
+  tf2::Vector3 near_field = transform * far_field;
+
+  EXPECT_FLOAT_EQ(-500, near_field.x());
+  EXPECT_FLOAT_EQ(-500, near_field.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * near_field;
+  EXPECT_FLOAT_EQ(far_field.x(), p3.x());
+  EXPECT_FLOAT_EQ(far_field.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, TfToTf1NoSlash)
+{
+  // Local Origin
+  tf2::Vector3 far_field(0, 0, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      "far_field",
+      transform));
+
+  tf2::Vector3 near_field = transform * far_field;
+
+  EXPECT_FLOAT_EQ(-500, near_field.x());
+  EXPECT_FLOAT_EQ(-500, near_field.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * near_field;
+  EXPECT_FLOAT_EQ(far_field.x(), p3.x());
+  EXPECT_FLOAT_EQ(far_field.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, TfToTf2)
+{
+  // Local Origin
+  tf2::Vector3 far_field(0, 0, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      "/far_field",
+      transform));
+
+  tf2::Vector3 near_field = transform * far_field;
+
+  EXPECT_FLOAT_EQ(-500, near_field.x());
+  EXPECT_FLOAT_EQ(-500, near_field.y());
+}
+
+TEST_F(TransformManagerTests, WgsToUtm)
+{
+  // San Antonio International Airport
+  tf2::Vector3 wgs84(-98.471944, 29.526667, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_utm_frame,
+      swri_transform_util::_wgs84_frame,
+      transform));
+
+  tf2::Vector3 utm = transform * wgs84;
+
+  EXPECT_FLOAT_EQ(551170, utm.x());
+  EXPECT_FLOAT_EQ(3266454, utm.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * utm;
+  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
+  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, WgsToUtmNoSlash)
+{
+  // San Antonio International Airport
+  tf2::Vector3 wgs84(-98.471944, 29.526667, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "utm",
+      "wgs84",
+      transform));
+
+  tf2::Vector3 utm = transform * wgs84;
+
+  EXPECT_FLOAT_EQ(551170, utm.x());
+  EXPECT_FLOAT_EQ(3266454, utm.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * utm;
+  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
+  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, UtmToWgs84)
+{
+  // San Antonio International Airport
+  tf2::Vector3 utm(551170, 3266454, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_wgs84_frame,
+      swri_transform_util::_utm_frame,
+      transform));
+
+  tf2::Vector3 wgs84 = transform * utm;
+
+  EXPECT_FLOAT_EQ(29.526667, wgs84.y());
+  EXPECT_FLOAT_EQ(-98.471944, wgs84.x());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * wgs84;
+  EXPECT_FLOAT_EQ(utm.x(), p3.x());
+  EXPECT_FLOAT_EQ(utm.y(), p3.y());
+}
+
+TEST_F(TransformManagerTests, TfToUtm1)
+{
+  // Local Origin
+  tf2::Vector3 tf(0, 0, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_utm_frame,
+      "/far_field",
+      transform));
+
+  tf2::Vector3 utm = transform * tf;
+
+  EXPECT_FLOAT_EQ(537460.3372816057, utm.x());
+  EXPECT_FLOAT_EQ(3258123.434110421, utm.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * utm;
+  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, TfToUtm1NoSlash)
+{
+  // Local Origin
+  tf2::Vector3 tf(0, 0, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "utm",
+      "far_field",
+      transform));
+
+  tf2::Vector3 utm = transform * tf;
+
+  EXPECT_FLOAT_EQ(537460.3372816057, utm.x());
+  EXPECT_FLOAT_EQ(3258123.434110421, utm.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * utm;
+  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, TfToUtm2)
+{
+  tf2::Vector3 tf(500, 500, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_utm_frame,
+      "/far_field",
+      transform));
+
+  tf2::Vector3 utm = transform * tf;
+
+  EXPECT_NEAR(537460.3372816057 + 500.0, utm.x(), 1.9);
+  EXPECT_NEAR(3258123.434110421 + 500.0, utm.y(), 1.5);
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * utm;
+  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, UtmToTf1)
+{
+  // Local Origin
+  tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/far_field",
+      swri_transform_util::_utm_frame,
+      transform));
+
+  tf2::Vector3 tf = transform * utm;
+
+  EXPECT_NEAR(0, tf.x(), 0.0005);
+  EXPECT_NEAR(0, tf.y(), 0.0005);
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, UtmToTf2)
+{
+  // Local Origin
+  tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      swri_transform_util::_utm_frame,
+      transform));
+
+  tf2::Vector3 tf = transform * utm;
+
+  EXPECT_NEAR(-500, tf.x(), 0.0005);
+  EXPECT_NEAR(-500, tf.y(), 0.0005);
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, UtmToTf3)
+{
+  // Local Origin
+  tf2::Vector3 utm(537460.3372816057 - 500, 3258123.434110421 - 500, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/far_field",
+      swri_transform_util::_utm_frame,
+      transform));
+
+  tf2::Vector3 tf = transform * utm;
+
+  EXPECT_NEAR(-500, tf.x(), 1.9);
+  EXPECT_NEAR(-500, tf.y(), 1.5);
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
+}
+
+TEST_F(TransformManagerTests, UtmToTf4)
+{
+  // San Antonio International Airport
+  tf2::Vector3 utm(551170, 3266454, 0);
+
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/far_field",
+      swri_transform_util::_utm_frame,
+      transform));
+
+  tf2::Vector3 tf = transform * utm;
+
+  EXPECT_FLOAT_EQ(13752.988, tf.x());
+  EXPECT_FLOAT_EQ(8280.0176, tf.y());
+
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
+}
 
 TEST_F(TransformManagerTests, Wgs84ToTf1)
 {
@@ -466,70 +466,70 @@ TEST_F(TransformManagerTests, Wgs84ToTf2)
   EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
 }
 
-/* TEST_F(TransformManagerTests, TfToWgs84_1) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 tf(0, 0, 0); */
+TEST_F(TransformManagerTests, TfToWgs84_1)
+{
+  // Local Origin
+  tf2::Vector3 tf(0, 0, 0);
 
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_wgs84_frame, */
-/*       "/far_field", */
-/*       transform)); */
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_wgs84_frame,
+      "/far_field",
+      transform));
 
-/*   tf2::Vector3 wgs84 = transform * tf; */
+  tf2::Vector3 wgs84 = transform * tf;
 
-/*   EXPECT_FLOAT_EQ(-98.61370577, wgs84.x()); */
-/*   EXPECT_FLOAT_EQ(29.45196669, wgs84.y()); */
+  EXPECT_FLOAT_EQ(-98.61370577, wgs84.x());
+  EXPECT_FLOAT_EQ(29.45196669, wgs84.y());
 
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * wgs84; */
-/*   EXPECT_FLOAT_EQ(tf.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(tf.y(), p3.y()); */
-/* } */
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * wgs84;
+  EXPECT_FLOAT_EQ(tf.x(), p3.x());
+  EXPECT_FLOAT_EQ(tf.y(), p3.y());
+}
 
-/* TEST_F(TransformManagerTests, TfToWgs84_1NoSlash) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 tf(0, 0, 0); */
+TEST_F(TransformManagerTests, TfToWgs84_1NoSlash)
+{
+  // Local Origin
+  tf2::Vector3 tf(0, 0, 0);
 
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       "wgs84", */
-/*       "far_field", */
-/*       transform)); */
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "wgs84",
+      "far_field",
+      transform));
 
-/*   tf2::Vector3 wgs84 = transform * tf; */
+  tf2::Vector3 wgs84 = transform * tf;
 
-/*   EXPECT_FLOAT_EQ(-98.61370577, wgs84.x()); */
-/*   EXPECT_FLOAT_EQ(29.45196669, wgs84.y()); */
+  EXPECT_FLOAT_EQ(-98.61370577, wgs84.x());
+  EXPECT_FLOAT_EQ(29.45196669, wgs84.y());
 
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * wgs84; */
-/*   EXPECT_FLOAT_EQ(tf.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(tf.y(), p3.y()); */
-/* } */
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * wgs84;
+  EXPECT_FLOAT_EQ(tf.x(), p3.x());
+  EXPECT_FLOAT_EQ(tf.y(), p3.y());
+}
 
-/* TEST_F(TransformManagerTests, TfToWgs84_2) */
-/* { */
-/*   tf2::Vector3 tf(0, 0, 0); */
+TEST_F(TransformManagerTests, TfToWgs84_2)
+{
+  tf2::Vector3 tf(0, 0, 0);
 
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager->GetTransform( */
-/*       swri_transform_util::_wgs84_frame, */
-/*       "/near_field", */
-/*       transform)); */
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      swri_transform_util::_wgs84_frame,
+      "/near_field",
+      transform));
 
-/*   tf2::Vector3 wgs84 = transform * tf; */
+  tf2::Vector3 wgs84 = transform * tf;
 
-/*   EXPECT_FLOAT_EQ(-98.6085519577, wgs84.x()); */
-/*   EXPECT_FLOAT_EQ(29.4564773982, wgs84.y()); */
+  EXPECT_FLOAT_EQ(-98.6085519577, wgs84.x());
+  EXPECT_FLOAT_EQ(29.4564773982, wgs84.y());
 
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * wgs84; */
-/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
-/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
-/* } */
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * wgs84;
+  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
+  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
+}
 
 // Run all the tests that were declared with TEST_F()
 int main(int argc, char **argv)

--- a/swri_transform_util/test/test_transform_manager.cpp
+++ b/swri_transform_util/test/test_transform_manager.cpp
@@ -29,495 +29,539 @@
 
 #include <gtest/gtest.h>
 
-#include <ros/ros.h>
-#include <tf/transform_datatypes.h>
+#include <atomic>
+#include <memory>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <tf2/transform_datatypes.h>
 
 #include <swri_transform_util/transform_manager.h>
 #include <swri_transform_util/frames.h>
 
-swri_transform_util::TransformManager _tf_manager;
+static std::shared_ptr<rclcpp::Node> _node;
+static std::shared_ptr<tf2_ros::TransformListener> _tf_listener;
+static std::shared_ptr<tf2_ros::Buffer> _tf_buffer;
+static std::shared_ptr<swri_transform_util::TransformManager> _tf_manager;
 
-TEST(TransformManagerTests, Identity1)
+class TransformManagerTests : public ::testing::Test
 {
-  tf::Vector3 p1(56, 234, 0);
+public:
+  void SetUp() override
+  {
+    ASSERT_TRUE(_tf_manager != nullptr);
+    // Wait until the local_xy_origin is setup correctly
+    bool origin_init = false;
+    for (size_t i=0; i < 10; ++i)
+    {
+      if (_tf_manager->SupportsTransform("far_field", "far_field__identity"))
+      {
+        origin_init = true;
+        break;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    ASSERT_TRUE(origin_init);
+  }
+};
+
+TEST_F(TransformManagerTests, Identity1)
+{
+  tf2::Vector3 p1(56, 234, 0);
 
   swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
+  ASSERT_TRUE(_tf_manager->GetTransform(
       "/near_field",
       "/near_field",
       transform));
 
-  tf::Vector3 p2 = transform * p1;
+  tf2::Vector3 p2 = transform * p1;
 
   EXPECT_FLOAT_EQ(p1.x(), p2.x());
   EXPECT_FLOAT_EQ(p1.y(), p2.y());
 
   swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * p2;
+  tf2::Vector3 p3 = inverse * p2;
   EXPECT_FLOAT_EQ(p1.x(), p3.x());
   EXPECT_FLOAT_EQ(p1.y(), p3.y());
 }
 
-TEST(TransformManagerTests, IdentityNoSlash)
-{
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
-      "near_field",
-      transform));
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "near_field",
-      "/near_field",
-      transform));
-}
+/* TEST_F(TransformManagerTests, IdentityNoSlash) */
+/* { */
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       "near_field", */
+/*       transform)); */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "near_field", */
+/*       "/near_field", */
+/*       transform)); */
+/* } */
 
-TEST(TransformManagerTests, Identity2)
-{
-  tf::Vector3 p1(435, -900, 0);
+/* TEST_F(TransformManagerTests, Identity2) */
+/* { */
+/*   tf2::Vector3 p1(435, -900, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/some_frame",
-      "/some_frame",
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/some_frame", */
+/*       "/some_frame", */
+/*       transform)); */
 
-  tf::Vector3 p2 = transform * p1;
+/*   tf2::Vector3 p2 = transform * p1; */
 
-  EXPECT_FLOAT_EQ(p1.x(), p2.x());
-  EXPECT_FLOAT_EQ(p1.y(), p2.y());
+/*   EXPECT_FLOAT_EQ(p1.x(), p2.x()); */
+/*   EXPECT_FLOAT_EQ(p1.y(), p2.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * p2;
-  EXPECT_FLOAT_EQ(p1.x(), p3.x());
-  EXPECT_FLOAT_EQ(p1.y(), p3.y());
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * p2; */
+/*   EXPECT_FLOAT_EQ(p1.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(p1.y(), p3.y()); */
+/* } */
 
-TEST(TransformManagerTests, TfToTf1)
+/* TEST_F(TransformManagerTests, TfToTf1) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 far_field(0, 0, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       "/far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 near_field = transform * far_field; */
+
+/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
+/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * near_field; */
+/*   EXPECT_FLOAT_EQ(far_field.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(far_field.y(), p3.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, TfToTf1NoSlash) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 far_field(0, 0, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       "far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 near_field = transform * far_field; */
+
+/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
+/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * near_field; */
+/*   EXPECT_FLOAT_EQ(far_field.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(far_field.y(), p3.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, TfToTf2) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 far_field(0, 0, 0); */
+
+/*   tf::StampedTransform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       "/far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 near_field = transform * far_field; */
+
+/*   EXPECT_FLOAT_EQ(-500, near_field.x()); */
+/*   EXPECT_FLOAT_EQ(-500, near_field.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, WgsToUtm) */
+/* { */
+/*   // San Antonio International Airport */
+/*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_utm_frame, */
+/*       swri_transform_util::_wgs84_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 utm = transform * wgs84; */
+
+/*   EXPECT_FLOAT_EQ(551170, utm.x()); */
+/*   EXPECT_FLOAT_EQ(3266454, utm.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * utm; */
+/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, WgsToUtmNoSlash) */
+/* { */
+/*   // San Antonio International Airport */
+/*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "utm", */
+/*       "wgs84", */
+/*       transform)); */
+
+/*   tf2::Vector3 utm = transform * wgs84; */
+
+/*   EXPECT_FLOAT_EQ(551170, utm.x()); */
+/*   EXPECT_FLOAT_EQ(3266454, utm.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * utm; */
+/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, UtmToWgs84) */
+/* { */
+/*   // San Antonio International Airport */
+/*   tf2::Vector3 utm(551170, 3266454, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_wgs84_frame, */
+/*       swri_transform_util::_utm_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 wgs84 = transform * utm; */
+
+/*   EXPECT_FLOAT_EQ(29.526667, wgs84.y()); */
+/*   EXPECT_FLOAT_EQ(-98.471944, wgs84.x()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * wgs84; */
+/*   EXPECT_FLOAT_EQ(utm.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(utm.y(), p3.y()); */
+/* } */
+
+/* TEST_F(TransformManagerTests, TfToUtm1) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 tf(0, 0, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_utm_frame, */
+/*       "/far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 utm = transform * tf; */
+
+/*   EXPECT_FLOAT_EQ(537460.3372816057, utm.x()); */
+/*   EXPECT_FLOAT_EQ(3258123.434110421, utm.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * utm; */
+/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, TfToUtm1NoSlash) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 tf(0, 0, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "utm", */
+/*       "far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 utm = transform * tf; */
+
+/*   EXPECT_FLOAT_EQ(537460.3372816057, utm.x()); */
+/*   EXPECT_FLOAT_EQ(3258123.434110421, utm.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * utm; */
+/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, TfToUtm2) */
+/* { */
+/*   tf2::Vector3 tf(500, 500, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_utm_frame, */
+/*       "/far_field", */
+/*       transform)); */
+
+/*   tf2::Vector3 utm = transform * tf; */
+
+/*   EXPECT_NEAR(537460.3372816057 + 500.0, utm.x(), 1.9); */
+/*   EXPECT_NEAR(3258123.434110421 + 500.0, utm.y(), 1.5); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * utm; */
+/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, UtmToTf1) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/far_field", */
+/*       swri_transform_util::_utm_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 tf = transform * utm; */
+
+/*   EXPECT_NEAR(0, tf.x(), 0.0005); */
+/*   EXPECT_NEAR(0, tf.y(), 0.0005); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, UtmToTf2) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       swri_transform_util::_utm_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 tf = transform * utm; */
+
+/*   EXPECT_NEAR(-500, tf.x(), 0.0005); */
+/*   EXPECT_NEAR(-500, tf.y(), 0.0005); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, UtmToTf3) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 utm(537460.3372816057 - 500, 3258123.434110421 - 500, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/far_field", */
+/*       swri_transform_util::_utm_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 tf = transform * utm; */
+
+/*   EXPECT_NEAR(-500, tf.x(), 1.9); */
+/*   EXPECT_NEAR(-500, tf.y(), 1.5); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
+/* } */
+
+/* TEST_F(TransformManagerTests, UtmToTf4) */
+/* { */
+/*   // San Antonio International Airport */
+/*   tf2::Vector3 utm(551170, 3266454, 0); */
+
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/far_field", */
+/*       swri_transform_util::_utm_frame, */
+/*       transform)); */
+
+/*   tf2::Vector3 tf = transform * utm; */
+
+/*   EXPECT_FLOAT_EQ(13752.988, tf.x()); */
+/*   EXPECT_FLOAT_EQ(8280.0176, tf.y()); */
+
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_NEAR(utm.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(utm.y(), p3.y(), 0.00000001); */
+/* } */
+
+TEST_F(TransformManagerTests, Wgs84ToTf1)
 {
   // Local Origin
-  tf::Vector3 far_field(0, 0, 0);
+  tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0);
 
   swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
+  ASSERT_TRUE(_tf_manager->GetTransform(
       "/far_field",
-      transform));
-
-  tf::Vector3 near_field = transform * far_field;
-
-  EXPECT_FLOAT_EQ(-500, near_field.x());
-  EXPECT_FLOAT_EQ(-500, near_field.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * near_field;
-  EXPECT_FLOAT_EQ(far_field.x(), p3.x());
-  EXPECT_FLOAT_EQ(far_field.y(), p3.y());
-}
-
-TEST(TransformManagerTests, TfToTf1NoSlash)
-{
-  // Local Origin
-  tf::Vector3 far_field(0, 0, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
-      "far_field",
-      transform));
-
-  tf::Vector3 near_field = transform * far_field;
-
-  EXPECT_FLOAT_EQ(-500, near_field.x());
-  EXPECT_FLOAT_EQ(-500, near_field.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * near_field;
-  EXPECT_FLOAT_EQ(far_field.x(), p3.x());
-  EXPECT_FLOAT_EQ(far_field.y(), p3.y());
-}
-
-TEST(TransformManagerTests, TfToTf2)
-{
-  // Local Origin
-  tf::Vector3 far_field(0, 0, 0);
-
-  tf::StampedTransform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
-      "/far_field",
-      transform));
-
-  tf::Vector3 near_field = transform * far_field;
-
-  EXPECT_FLOAT_EQ(-500, near_field.x());
-  EXPECT_FLOAT_EQ(-500, near_field.y());
-}
-
-TEST(TransformManagerTests, WgsToUtm)
-{
-  // San Antonio International Airport
-  tf::Vector3 wgs84(-98.471944, 29.526667, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_utm_frame,
       swri_transform_util::_wgs84_frame,
       transform));
 
-  tf::Vector3 utm = transform * wgs84;
-
-  EXPECT_FLOAT_EQ(551170, utm.x());
-  EXPECT_FLOAT_EQ(3266454, utm.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * utm;
-  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
-  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
-}
-
-TEST(TransformManagerTests, WgsToUtmNoSlash)
-{
-  // San Antonio International Airport
-  tf::Vector3 wgs84(-98.471944, 29.526667, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "utm",
-      "wgs84",
-      transform));
-
-  tf::Vector3 utm = transform * wgs84;
-
-  EXPECT_FLOAT_EQ(551170, utm.x());
-  EXPECT_FLOAT_EQ(3266454, utm.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * utm;
-  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
-  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
-}
-
-TEST(TransformManagerTests, UtmToWgs84)
-{
-  // San Antonio International Airport
-  tf::Vector3 utm(551170, 3266454, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_wgs84_frame,
-      swri_transform_util::_utm_frame,
-      transform));
-
-  tf::Vector3 wgs84 = transform * utm;
-
-  EXPECT_FLOAT_EQ(29.526667, wgs84.y());
-  EXPECT_FLOAT_EQ(-98.471944, wgs84.x());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * wgs84;
-  EXPECT_FLOAT_EQ(utm.x(), p3.x());
-  EXPECT_FLOAT_EQ(utm.y(), p3.y());
-}
-
-TEST(TransformManagerTests, TfToUtm1)
-{
-  // Local Origin
-  tf::Vector3 tf(0, 0, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_utm_frame,
-      "/far_field",
-      transform));
-
-  tf::Vector3 utm = transform * tf;
-
-  EXPECT_FLOAT_EQ(537460.3372816057, utm.x());
-  EXPECT_FLOAT_EQ(3258123.434110421, utm.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * utm;
-  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, TfToUtm1NoSlash)
-{
-  // Local Origin
-  tf::Vector3 tf(0, 0, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "utm",
-      "far_field",
-      transform));
-
-  tf::Vector3 utm = transform * tf;
-
-  EXPECT_FLOAT_EQ(537460.3372816057, utm.x());
-  EXPECT_FLOAT_EQ(3258123.434110421, utm.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * utm;
-  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, TfToUtm2)
-{
-  tf::Vector3 tf(500, 500, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_utm_frame,
-      "/far_field",
-      transform));
-
-  tf::Vector3 utm = transform * tf;
-
-  EXPECT_NEAR(537460.3372816057 + 500.0, utm.x(), 1.9);
-  EXPECT_NEAR(3258123.434110421 + 500.0, utm.y(), 1.5);
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * utm;
-  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, UtmToTf1)
-{
-  // Local Origin
-  tf::Vector3 utm(537460.3372816057, 3258123.434110421, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/far_field",
-      swri_transform_util::_utm_frame,
-      transform));
-
-  tf::Vector3 tf = transform * utm;
-
-  EXPECT_NEAR(0, tf.x(), 0.0005);
-  EXPECT_NEAR(0, tf.y(), 0.0005);
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, UtmToTf2)
-{
-  // Local Origin
-  tf::Vector3 utm(537460.3372816057, 3258123.434110421, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
-      swri_transform_util::_utm_frame,
-      transform));
-
-  tf::Vector3 tf = transform * utm;
-
-  EXPECT_NEAR(-500, tf.x(), 0.0005);
-  EXPECT_NEAR(-500, tf.y(), 0.0005);
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, UtmToTf3)
-{
-  // Local Origin
-  tf::Vector3 utm(537460.3372816057 - 500, 3258123.434110421 - 500, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/far_field",
-      swri_transform_util::_utm_frame,
-      transform));
-
-  tf::Vector3 tf = transform * utm;
-
-  EXPECT_NEAR(-500, tf.x(), 1.9);
-  EXPECT_NEAR(-500, tf.y(), 1.5);
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, UtmToTf4)
-{
-  // San Antonio International Airport
-  tf::Vector3 utm(551170, 3266454, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/far_field",
-      swri_transform_util::_utm_frame,
-      transform));
-
-  tf::Vector3 tf = transform * utm;
-
-  EXPECT_FLOAT_EQ(13752.988, tf.x());
-  EXPECT_FLOAT_EQ(8280.0176, tf.y());
-
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_NEAR(utm.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(utm.y(), p3.y(), 0.00000001);
-}
-
-TEST(TransformManagerTests, Wgs84ToTf1)
-{
-  // Local Origin
-  tf::Vector3 wgs84(-98.61370577, 29.45196669, 0);
-
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/far_field",
-      swri_transform_util::_wgs84_frame,
-      transform));
-
-  tf::Vector3 tf = transform * wgs84;
+  tf2::Vector3 tf = transform * wgs84;
 
   EXPECT_FLOAT_EQ(0, tf.x());
   EXPECT_FLOAT_EQ(0, tf.y());
 
   swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
+  tf2::Vector3 p3 = inverse * tf;
   EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
   EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
 }
 
-TEST(TransformManagerTests, Wgs84ToTf1NoSlash)
-{
-  // Local Origin
-  tf::Vector3 wgs84(-98.61370577, 29.45196669, 0);
+/* TEST_F(TransformManagerTests, Wgs84ToTf1NoSlash) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "far_field",
-      "wgs84",
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "far_field", */
+/*       "wgs84", */
+/*       transform)); */
 
-  tf::Vector3 tf = transform * wgs84;
+/*   tf2::Vector3 tf = transform * wgs84; */
 
-  EXPECT_FLOAT_EQ(0, tf.x());
-  EXPECT_FLOAT_EQ(0, tf.y());
+/*   EXPECT_FLOAT_EQ(0, tf.x()); */
+/*   EXPECT_FLOAT_EQ(0, tf.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
-  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
+/* } */
 
-TEST(TransformManagerTests, Wgs84ToTf2)
-{
-  // Local Origin
-  tf::Vector3 wgs84(-98.61370577, 29.45196669, 0);
+/* TEST_F(TransformManagerTests, Wgs84ToTf2) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "/near_field",
-      swri_transform_util::_wgs84_frame,
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "/near_field", */
+/*       swri_transform_util::_wgs84_frame, */
+/*       transform)); */
 
-  tf::Vector3 tf = transform * wgs84;
+/*   tf2::Vector3 tf = transform * wgs84; */
 
-  EXPECT_FLOAT_EQ(-500, tf.x());
-  EXPECT_FLOAT_EQ(-500, tf.y());
+/*   EXPECT_FLOAT_EQ(-500, tf.x()); */
+/*   EXPECT_FLOAT_EQ(-500, tf.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * tf;
-  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
-  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * tf; */
+/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
+/* } */
 
-TEST(TransformManagerTests, TfToWgs84_1)
-{
-  // Local Origin
-  tf::Vector3 tf(0, 0, 0);
+/* TEST_F(TransformManagerTests, TfToWgs84_1) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 tf(0, 0, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_wgs84_frame,
-      "/far_field",
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_wgs84_frame, */
+/*       "/far_field", */
+/*       transform)); */
 
-  tf::Vector3 wgs84 = transform * tf;
+/*   tf2::Vector3 wgs84 = transform * tf; */
 
-  EXPECT_FLOAT_EQ(-98.61370577, wgs84.x());
-  EXPECT_FLOAT_EQ(29.45196669, wgs84.y());
+/*   EXPECT_FLOAT_EQ(-98.61370577, wgs84.x()); */
+/*   EXPECT_FLOAT_EQ(29.45196669, wgs84.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * wgs84;
-  EXPECT_FLOAT_EQ(tf.x(), p3.x());
-  EXPECT_FLOAT_EQ(tf.y(), p3.y());
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * wgs84; */
+/*   EXPECT_FLOAT_EQ(tf.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(tf.y(), p3.y()); */
+/* } */
 
-TEST(TransformManagerTests, TfToWgs84_1NoSlash)
-{
-  // Local Origin
-  tf::Vector3 tf(0, 0, 0);
+/* TEST_F(TransformManagerTests, TfToWgs84_1NoSlash) */
+/* { */
+/*   // Local Origin */
+/*   tf2::Vector3 tf(0, 0, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      "wgs84",
-      "far_field",
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       "wgs84", */
+/*       "far_field", */
+/*       transform)); */
 
-  tf::Vector3 wgs84 = transform * tf;
+/*   tf2::Vector3 wgs84 = transform * tf; */
 
-  EXPECT_FLOAT_EQ(-98.61370577, wgs84.x());
-  EXPECT_FLOAT_EQ(29.45196669, wgs84.y());
+/*   EXPECT_FLOAT_EQ(-98.61370577, wgs84.x()); */
+/*   EXPECT_FLOAT_EQ(29.45196669, wgs84.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * wgs84;
-  EXPECT_FLOAT_EQ(tf.x(), p3.x());
-  EXPECT_FLOAT_EQ(tf.y(), p3.y());
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * wgs84; */
+/*   EXPECT_FLOAT_EQ(tf.x(), p3.x()); */
+/*   EXPECT_FLOAT_EQ(tf.y(), p3.y()); */
+/* } */
 
-TEST(TransformManagerTests, TfToWgs84_2)
-{
-  tf::Vector3 tf(0, 0, 0);
+/* TEST_F(TransformManagerTests, TfToWgs84_2) */
+/* { */
+/*   tf2::Vector3 tf(0, 0, 0); */
 
-  swri_transform_util::Transform transform;
-  ASSERT_TRUE(_tf_manager.GetTransform(
-      swri_transform_util::_wgs84_frame,
-      "/near_field",
-      transform));
+/*   swri_transform_util::Transform transform; */
+/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*       swri_transform_util::_wgs84_frame, */
+/*       "/near_field", */
+/*       transform)); */
 
-  tf::Vector3 wgs84 = transform * tf;
+/*   tf2::Vector3 wgs84 = transform * tf; */
 
-  EXPECT_FLOAT_EQ(-98.6085519577, wgs84.x());
-  EXPECT_FLOAT_EQ(29.4564773982, wgs84.y());
+/*   EXPECT_FLOAT_EQ(-98.6085519577, wgs84.x()); */
+/*   EXPECT_FLOAT_EQ(29.4564773982, wgs84.y()); */
 
-  swri_transform_util::Transform inverse = transform.Inverse();
-  tf::Vector3 p3 = inverse * wgs84;
-  EXPECT_NEAR(tf.x(), p3.x(), 0.00000001);
-  EXPECT_NEAR(tf.y(), p3.y(), 0.00000001);
-}
+/*   swri_transform_util::Transform inverse = transform.Inverse(); */
+/*   tf2::Vector3 p3 = inverse * wgs84; */
+/*   EXPECT_NEAR(tf.x(), p3.x(), 0.00000001); */
+/*   EXPECT_NEAR(tf.y(), p3.y(), 0.00000001); */
+/* } */
 
-// Run all the tests that were declared with TEST()
+// Run all the tests that were declared with TEST_F()
 int main(int argc, char **argv)
 {
+  rclcpp::init(argc, argv);
   testing::InitGoogleTest(&argc, argv);
 
-  // Initialize the ROS core parameters can be loaded from the launch file
-  ros::init(argc, argv, "test_transform_manager");
+  _node = rclcpp::Node::make_shared("transform_manager_test");
+  _tf_buffer = std::make_shared<tf2_ros::Buffer>(_node->get_clock());
+  _tf_listener = std::make_shared<tf2_ros::TransformListener>(*_tf_buffer, _node);
 
-  _tf_manager.Initialize();
+  _tf_manager = std::make_shared<swri_transform_util::TransformManager>(_node, _tf_buffer);
 
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
-  sleep(10);
+  // background spinner thread using main executor
+  std::atomic<bool> tests_done = false;
+  std::thread spinner = std::thread([&tests_done]() {
+      while (not tests_done)
+      {
+        rclcpp::spin_some(_node);
+      }
+  });
 
-  bool result = RUN_ALL_TESTS();
-  spinner.stop();
+  int result = RUN_ALL_TESTS();
+  tests_done = true;
+  if (spinner.joinable())
+  {
+    spinner.join();
+  }
+  rclcpp::shutdown();
+  _tf_manager.reset();
+  _tf_listener.reset();
+  _tf_buffer.reset();
+  _node.reset();
   return result;
 }

--- a/swri_transform_util/test/test_transform_manager.cpp
+++ b/swri_transform_util/test/test_transform_manager.cpp
@@ -89,11 +89,11 @@ TEST_F(TransformManagerTests, Identity1)
 /* TEST_F(TransformManagerTests, IdentityNoSlash) */
 /* { */
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/near_field", */
 /*       "near_field", */
 /*       transform)); */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "near_field", */
 /*       "/near_field", */
 /*       transform)); */
@@ -104,7 +104,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 p1(435, -900, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/some_frame", */
 /*       "/some_frame", */
 /*       transform)); */
@@ -126,7 +126,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 far_field(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/near_field", */
 /*       "/far_field", */
 /*       transform)); */
@@ -148,7 +148,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 far_field(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/near_field", */
 /*       "far_field", */
 /*       transform)); */
@@ -170,7 +170,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 far_field(0, 0, 0); */
 
 /*   tf::StampedTransform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/near_field", */
 /*       "/far_field", */
 /*       transform)); */
@@ -187,7 +187,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_utm_frame, */
 /*       swri_transform_util::_wgs84_frame, */
 /*       transform)); */
@@ -209,7 +209,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 wgs84(-98.471944, 29.526667, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "utm", */
 /*       "wgs84", */
 /*       transform)); */
@@ -231,7 +231,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 utm(551170, 3266454, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_wgs84_frame, */
 /*       swri_transform_util::_utm_frame, */
 /*       transform)); */
@@ -253,7 +253,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 tf(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_utm_frame, */
 /*       "/far_field", */
 /*       transform)); */
@@ -275,7 +275,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 tf(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "utm", */
 /*       "far_field", */
 /*       transform)); */
@@ -296,7 +296,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 tf(500, 500, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_utm_frame, */
 /*       "/far_field", */
 /*       transform)); */
@@ -318,7 +318,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/far_field", */
 /*       swri_transform_util::_utm_frame, */
 /*       transform)); */
@@ -340,7 +340,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 utm(537460.3372816057, 3258123.434110421, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/near_field", */
 /*       swri_transform_util::_utm_frame, */
 /*       transform)); */
@@ -362,7 +362,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 utm(537460.3372816057 - 500, 3258123.434110421 - 500, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/far_field", */
 /*       swri_transform_util::_utm_frame, */
 /*       transform)); */
@@ -384,7 +384,7 @@ TEST_F(TransformManagerTests, Identity1)
 /*   tf2::Vector3 utm(551170, 3266454, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "/far_field", */
 /*       swri_transform_util::_utm_frame, */
 /*       transform)); */
@@ -422,49 +422,49 @@ TEST_F(TransformManagerTests, Wgs84ToTf1)
   EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
 }
 
-/* TEST_F(TransformManagerTests, Wgs84ToTf1NoSlash) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0); */
+TEST_F(TransformManagerTests, Wgs84ToTf1NoSlash)
+{
+  // Local Origin
+  tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0);
 
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
-/*       "far_field", */
-/*       "wgs84", */
-/*       transform)); */
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "far_field",
+      "wgs84",
+      transform));
 
-/*   tf2::Vector3 tf = transform * wgs84; */
+  tf2::Vector3 tf = transform * wgs84;
 
-/*   EXPECT_FLOAT_EQ(0, tf.x()); */
-/*   EXPECT_FLOAT_EQ(0, tf.y()); */
+  EXPECT_FLOAT_EQ(0, tf.x());
+  EXPECT_FLOAT_EQ(0, tf.y());
 
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
-/* } */
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
+  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
+}
 
-/* TEST_F(TransformManagerTests, Wgs84ToTf2) */
-/* { */
-/*   // Local Origin */
-/*   tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0); */
+TEST_F(TransformManagerTests, Wgs84ToTf2)
+{
+  // Local Origin
+  tf2::Vector3 wgs84(-98.61370577, 29.45196669, 0);
 
-/*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
-/*       "/near_field", */
-/*       swri_transform_util::_wgs84_frame, */
-/*       transform)); */
+  swri_transform_util::Transform transform;
+  ASSERT_TRUE(_tf_manager->GetTransform(
+      "/near_field",
+      swri_transform_util::_wgs84_frame,
+      transform));
 
-/*   tf2::Vector3 tf = transform * wgs84; */
+  tf2::Vector3 tf = transform * wgs84;
 
-/*   EXPECT_FLOAT_EQ(-500, tf.x()); */
-/*   EXPECT_FLOAT_EQ(-500, tf.y()); */
+  EXPECT_FLOAT_EQ(-500, tf.x());
+  EXPECT_FLOAT_EQ(-500, tf.y());
 
-/*   swri_transform_util::Transform inverse = transform.Inverse(); */
-/*   tf2::Vector3 p3 = inverse * tf; */
-/*   EXPECT_FLOAT_EQ(wgs84.x(), p3.x()); */
-/*   EXPECT_FLOAT_EQ(wgs84.y(), p3.y()); */
-/* } */
+  swri_transform_util::Transform inverse = transform.Inverse();
+  tf2::Vector3 p3 = inverse * tf;
+  EXPECT_FLOAT_EQ(wgs84.x(), p3.x());
+  EXPECT_FLOAT_EQ(wgs84.y(), p3.y());
+}
 
 /* TEST_F(TransformManagerTests, TfToWgs84_1) */
 /* { */
@@ -472,7 +472,7 @@ TEST_F(TransformManagerTests, Wgs84ToTf1)
 /*   tf2::Vector3 tf(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_wgs84_frame, */
 /*       "/far_field", */
 /*       transform)); */
@@ -494,7 +494,7 @@ TEST_F(TransformManagerTests, Wgs84ToTf1)
 /*   tf2::Vector3 tf(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       "wgs84", */
 /*       "far_field", */
 /*       transform)); */
@@ -515,7 +515,7 @@ TEST_F(TransformManagerTests, Wgs84ToTf1)
 /*   tf2::Vector3 tf(0, 0, 0); */
 
 /*   swri_transform_util::Transform transform; */
-/*   ASSERT_TRUE(_tf_manager.GetTransform( */
+/*   ASSERT_TRUE(_tf_manager->GetTransform( */
 /*       swri_transform_util::_wgs84_frame, */
 /*       "/near_field", */
 /*       transform)); */

--- a/swri_transform_util/test/test_transform_util.cpp
+++ b/swri_transform_util/test/test_transform_util.cpp
@@ -29,11 +29,11 @@
 
 #include <cstdlib>
 
-#include <array.hpp>
+#include <array>
 
 #include <gtest/gtest.h>
 
-#include <ros/ros.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include <swri_math_util/constants.h>
 #include <swri_math_util/math_util.h>
@@ -41,12 +41,12 @@
 
 TEST(TransformUtilTests, GetRelativeTransform)
 {
-  tf::Transform offset = swri_transform_util::GetRelativeTransform(
+  tf2::Transform offset = swri_transform_util::GetRelativeTransform(
                 29.441679990508018, -98.602031700252184, -1.2030287,
                 29.441609529848606, -98.601997698933161, -1.21015707397341
                 );
 
-  tf::Vector3 origin = offset.getOrigin();
+  tf2::Vector3 origin = offset.getOrigin();
   EXPECT_FLOAT_EQ(-8.47174665, origin.x());
   EXPECT_FLOAT_EQ(-0.3306987, origin.y());
   EXPECT_FLOAT_EQ(0.0, origin.z());
@@ -62,18 +62,18 @@ TEST(TransformUtilTests, GetBearing)
 
 TEST(TransformUtilTests, SnapToRightAngle1)
 {
-  tf::Quaternion identity = tf::Quaternion::getIdentity();
+  tf2::Quaternion identity = tf2::Quaternion::getIdentity();
 
   EXPECT_TRUE(identity == swri_transform_util::SnapToRightAngle(identity));
 
-  tf::Quaternion q1;
+  tf2::Quaternion q1;
   q1.setRPY(0.0, 0.0, swri_math_util::_half_pi);
   q1.normalize();
 
-  tf::Quaternion q2;
+  tf2::Quaternion q2;
   q2.setRPY(0.4, 0.3, 1.6);
 
-  tf::Quaternion q3 = swri_transform_util::SnapToRightAngle(q2);
+  tf2::Quaternion q3 = swri_transform_util::SnapToRightAngle(q2);
 
   EXPECT_FLOAT_EQ(q1.x(), q3.x());
   EXPECT_FLOAT_EQ(q1.y(), q3.y());
@@ -84,21 +84,21 @@ TEST(TransformUtilTests, SnapToRightAngle1)
 
 TEST(TransformUtilTests, SnapToRightAngle2)
 {
-  tf::Quaternion q1;
+  tf2::Quaternion q1;
   q1.setRPY(0.0, 0.0, swri_math_util::_half_pi);
 
   EXPECT_EQ(0, q1.angleShortestPath(swri_transform_util::SnapToRightAngle(q1)));
 
-  tf::Quaternion q2;
+  tf2::Quaternion q2;
   q2.setRPY(0.0, 0.0, swri_math_util::_pi);
 
   EXPECT_EQ(0, q2.angleShortestPath(swri_transform_util::SnapToRightAngle(q2)));
 
-  tf::Quaternion q3;
+  tf2::Quaternion q3;
   q3.setRPY(0.0, 0.0, swri_math_util::_pi + .34);
   EXPECT_EQ(0, q2.angleShortestPath(swri_transform_util::SnapToRightAngle(q3)));
 
-  tf::Quaternion q4;
+  tf2::Quaternion q4;
   q4.setRPY(-0.4, 0.23, swri_math_util::_pi + 0.34);
   EXPECT_EQ(0, q2.angleShortestPath(swri_transform_util::SnapToRightAngle(q4)));
 }
@@ -113,14 +113,14 @@ TEST(TransformUtilTests, SnapToRightAngleRandom)
     double p = swri_math_util::Round((static_cast<double>(std::rand()) / RAND_MAX) * 4.0 - 2.0) * swri_math_util::_half_pi;
     double r = swri_math_util::Round((static_cast<double>(std::rand()) / RAND_MAX) * 2.0 - 1.0) * swri_math_util::_half_pi;
 
-    tf::Quaternion q1;
+    tf2::Quaternion q1;
     q1.setRPY(r, p, y);
 
     double dy = (static_cast<double>(std::rand()) / RAND_MAX) * swri_math_util::_half_pi * .5 - swri_math_util::_half_pi * .25;
     double dp = (static_cast<double>(std::rand()) / RAND_MAX) * swri_math_util::_half_pi * .5 - swri_math_util::_half_pi * .25;
     double dr = (static_cast<double>(std::rand()) / RAND_MAX) * swri_math_util::_half_pi * .5 - swri_math_util::_half_pi * .25;
 
-    tf::Quaternion q2;
+    tf2::Quaternion q2;
     q2.setRPY(r + dr, p + dp, y + dy);
 
 
@@ -139,10 +139,10 @@ TEST(TransformUtilTests, SnapToRightAngleDegenerate1)
   double dp = 0.2254961365127778616379572440564516000449657440185546875;
   double dr = 0.38988573881896215755915591216762550175189971923828125;
 
-  tf::Quaternion q1;
+  tf2::Quaternion q1;
   q1.setRPY(r, p, y);
 
-  tf::Quaternion q2;
+  tf2::Quaternion q2;
   q2.setRPY(r + dr, p + dp, y + dy);
 
   EXPECT_NEAR(0, q1.angleShortestPath(swri_transform_util::SnapToRightAngle(q1)), 0.00000003);
@@ -159,10 +159,10 @@ TEST(TransformUtilTests, SnapToRightAngleDegenerate2)
   double dp = 0.363762144414233323796992181087261997163295745849609375;
   double dr = -0.38101948131676321995797707131714560091495513916015625;
 
-  tf::Quaternion q1;
+  tf2::Quaternion q1;
   q1.setRPY(r, p, y);
 
-  tf::Quaternion q2;
+  tf2::Quaternion q2;
   q2.setRPY(r + dr, p + dp, y + dy);
 
   EXPECT_NEAR(0, q1.angleShortestPath(swri_transform_util::SnapToRightAngle(q1)), 0.00000003);
@@ -171,16 +171,16 @@ TEST(TransformUtilTests, SnapToRightAngleDegenerate2)
 
 TEST(TransformUtilTests, TestUpperLeftLowerRight)
 {
-  tf::Matrix3x3 ul(1, 2, 3, 4, 5, 6, 7, 8, 9);
-  tf::Matrix3x3 lr(10, 11, 12, 13, 14, 15, 16, 17, 18);
+  tf2::Matrix3x3 ul(1, 2, 3, 4, 5, 6, 7, 8, 9);
+  tf2::Matrix3x3 lr(10, 11, 12, 13, 14, 15, 16, 17, 18);
 
   std::array<double, 36> array;
 
   swri_transform_util::SetUpperLeft(ul, array);
   swri_transform_util::SetLowerRight(lr, array);
 
-  tf::Matrix3x3 ul2 = swri_transform_util::GetUpperLeft(array);
-  tf::Matrix3x3 lr2 = swri_transform_util::GetLowerRight(array);
+  tf2::Matrix3x3 ul2 = swri_transform_util::GetUpperLeft(array);
+  tf2::Matrix3x3 lr2 = swri_transform_util::GetLowerRight(array);
 
   EXPECT_EQ(ul, ul2);
   EXPECT_EQ(lr, lr2);
@@ -191,16 +191,16 @@ TEST(TransformUtilTests, TestUpperLeftLowerRight)
 
 TEST(TransformUtilTests, GetPrimaryAxis)
 {
-  tf::Vector3 v1(-1, 0, 0);
-  tf::Vector3 v2(-.7, .3, 0);
+  tf2::Vector3 v1(-1, 0, 0);
+  tf2::Vector3 v2(-.7, .3, 0);
 
-  tf::Vector3 v3(0, 1, 0);
-  tf::Vector3 v4(.6, .61, .3);
+  tf2::Vector3 v3(0, 1, 0);
+  tf2::Vector3 v4(.6, .61, .3);
 
-  tf::Vector3 v5(0, 0, 1);
-  tf::Vector3 v6(-.23, .3, .5);
+  tf2::Vector3 v5(0, 0, 1);
+  tf2::Vector3 v6(-.23, .3, .5);
 
-  tf::Vector3 v7(0, 0, 0);
+  tf2::Vector3 v7(0, 0, 0);
 
   EXPECT_EQ(v1, swri_transform_util::GetPrimaryAxis(v1));
   EXPECT_EQ(v1, swri_transform_util::GetPrimaryAxis(v2));
@@ -216,31 +216,31 @@ TEST(TransformUtilTests, GetPrimaryAxis)
 
 TEST(TransformUtilTests, ValidIsRotation)
 {
-  tf::Matrix3x3 valid_rotations[] = {
-  tf::Matrix3x3( 1,  0,  0,   0,  1,  0,   0,  0,  1),
-  tf::Matrix3x3( 0,  0,  1,   0,  1,  0,  -1,  0,  0),
-  tf::Matrix3x3(-1,  0,  0,   0,  1,  0,   0,  0, -1),
-  tf::Matrix3x3( 0,  0, -1,   0,  1,  0,   1,  0,  0),
-  tf::Matrix3x3( 0, -1,  0,   1,  0,  0,   0,  0,  1),
-  tf::Matrix3x3( 0,  0,  1,   1,  0,  0,   0,  1,  0),
-  tf::Matrix3x3( 0,  1,  0,   1,  0,  0,   0,  0, -1),
-  tf::Matrix3x3( 0,  0, -1,   1,  0,  0,   0, -1,  0),
-  tf::Matrix3x3( 0,  1,  0,  -1,  0,  0,   0,  0,  1),
-  tf::Matrix3x3( 0,  0,  1,  -1,  0,  0,   0, -1,  0),
-  tf::Matrix3x3( 0, -1,  0,  -1,  0,  0,   0,  0, -1),
-  tf::Matrix3x3( 0,  0, -1,  -1,  0,  0,   0,  1,  0),
-  tf::Matrix3x3( 1,  0,  0,   0,  0, -1,   0,  1,  0),
-  tf::Matrix3x3( 0,  1,  0,   0,  0, -1,  -1,  0,  0),
-  tf::Matrix3x3(-1,  0,  0,   0,  0, -1,   0, -1,  0),
-  tf::Matrix3x3( 0, -1,  0,   0,  0, -1,   1,  0,  0),
-  tf::Matrix3x3( 1,  0,  0,   0, -1,  0,   0,  0, -1),
-  tf::Matrix3x3( 0,  0, -1,   0, -1,  0,  -1,  0,  0),
-  tf::Matrix3x3(-1,  0,  0,   0, -1,  0,   0,  0,  1),
-  tf::Matrix3x3( 0,  0,  1,   0, -1,  0,   1,  0,  0),
-  tf::Matrix3x3( 1,  0,  0,   0,  0,  1,   0, -1,  0),
-  tf::Matrix3x3( 0, -1,  0,   0,  0,  1,  -1,  0,  0),
-  tf::Matrix3x3(-1,  0,  0,   0,  0,  1,   0,  1,  0),
-  tf::Matrix3x3( 0,  1,  0,   0,  0,  1,   1,  0,  0)};
+  tf2::Matrix3x3 valid_rotations[] = {
+  tf2::Matrix3x3( 1,  0,  0,   0,  1,  0,   0,  0,  1),
+  tf2::Matrix3x3( 0,  0,  1,   0,  1,  0,  -1,  0,  0),
+  tf2::Matrix3x3(-1,  0,  0,   0,  1,  0,   0,  0, -1),
+  tf2::Matrix3x3( 0,  0, -1,   0,  1,  0,   1,  0,  0),
+  tf2::Matrix3x3( 0, -1,  0,   1,  0,  0,   0,  0,  1),
+  tf2::Matrix3x3( 0,  0,  1,   1,  0,  0,   0,  1,  0),
+  tf2::Matrix3x3( 0,  1,  0,   1,  0,  0,   0,  0, -1),
+  tf2::Matrix3x3( 0,  0, -1,   1,  0,  0,   0, -1,  0),
+  tf2::Matrix3x3( 0,  1,  0,  -1,  0,  0,   0,  0,  1),
+  tf2::Matrix3x3( 0,  0,  1,  -1,  0,  0,   0, -1,  0),
+  tf2::Matrix3x3( 0, -1,  0,  -1,  0,  0,   0,  0, -1),
+  tf2::Matrix3x3( 0,  0, -1,  -1,  0,  0,   0,  1,  0),
+  tf2::Matrix3x3( 1,  0,  0,   0,  0, -1,   0,  1,  0),
+  tf2::Matrix3x3( 0,  1,  0,   0,  0, -1,  -1,  0,  0),
+  tf2::Matrix3x3(-1,  0,  0,   0,  0, -1,   0, -1,  0),
+  tf2::Matrix3x3( 0, -1,  0,   0,  0, -1,   1,  0,  0),
+  tf2::Matrix3x3( 1,  0,  0,   0, -1,  0,   0,  0, -1),
+  tf2::Matrix3x3( 0,  0, -1,   0, -1,  0,  -1,  0,  0),
+  tf2::Matrix3x3(-1,  0,  0,   0, -1,  0,   0,  0,  1),
+  tf2::Matrix3x3( 0,  0,  1,   0, -1,  0,   1,  0,  0),
+  tf2::Matrix3x3( 1,  0,  0,   0,  0,  1,   0, -1,  0),
+  tf2::Matrix3x3( 0, -1,  0,   0,  0,  1,  -1,  0,  0),
+  tf2::Matrix3x3(-1,  0,  0,   0,  0,  1,   0,  1,  0),
+  tf2::Matrix3x3( 0,  1,  0,   0,  0,  1,   1,  0,  0)};
 
   for (int i = 0; i < 24; i++)
   {
@@ -250,10 +250,10 @@ TEST(TransformUtilTests, ValidIsRotation)
 
 TEST(TransformUtilTests, InvalidIsRotation)
 {
-  tf::Matrix3x3 invalid_rotations[] = {
-  tf::Matrix3x3( 2,  0,  0,   0,  1,  0,   0,  0,  1),
-  tf::Matrix3x3( 0,  0,  1,   0,  0,  0,  -1,  0,  0),
-  tf::Matrix3x3(-1,  1,  0,   0,  1,  0,   0,  0, -1)};
+  tf2::Matrix3x3 invalid_rotations[] = {
+  tf2::Matrix3x3( 2,  0,  0,   0,  1,  0,   0,  0,  1),
+  tf2::Matrix3x3( 0,  0,  1,   0,  0,  0,  -1,  0,  0),
+  tf2::Matrix3x3(-1,  1,  0,   0,  1,  0,   0,  0, -1)};
 
   for (int i = 0; i < 24; i++)
   {
@@ -267,7 +267,7 @@ int main(int argc, char **argv)
   testing::InitGoogleTest(&argc, argv);
 
   // Initialize the ROS core parameters can be loaded from the launch file
-  ros::init(argc, argv, "test_transform_util");
+  rclcpp::init(argc, argv);
 
   return RUN_ALL_TESTS();
 }

--- a/swri_transform_util/test/test_utm_util.cpp
+++ b/swri_transform_util/test/test_utm_util.cpp
@@ -72,45 +72,45 @@ TEST(UtmUtilTests, ToUtm)
   utm_util.ToUtm(33.9425, -118.408056, zone, band, easting, northing);
   EXPECT_EQ(11, zone);
   EXPECT_EQ('S', band);
-  EXPECT_NEAR(369877, easting, 0.5);
-  EXPECT_FLOAT_EQ(3756673, northing);
+  EXPECT_NEAR(369877.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(3756673.0, northing);
 
   utm_util.ToUtm(33.9425, -118.408056, easting, northing);
-  EXPECT_NEAR(369877, easting, 0.5);
-  EXPECT_FLOAT_EQ(3756673, northing);
+  EXPECT_NEAR(369877.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(3756673.0, northing);
 
   // MIA
   utm_util.ToUtm(25.793333, -80.290556, zone, band, easting, northing);
   EXPECT_EQ(17, zone);
   EXPECT_EQ('R', band);
-  EXPECT_NEAR(571124, easting, 0.5);
-  EXPECT_FLOAT_EQ(2852989, northing);
+  EXPECT_NEAR(571124.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(2852989.0, northing);
 
   utm_util.ToUtm(25.793333, -80.290556, easting, northing);
-  EXPECT_NEAR(571124, easting, 0.5);
-  EXPECT_FLOAT_EQ(2852989, northing);
+  EXPECT_NEAR(571124.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(2852989.0, northing);
 
   // USH
   utm_util.ToUtm(-54.843333, -68.295556, zone, band, easting, northing);
   EXPECT_EQ(19, zone);
   EXPECT_EQ('F', band);
-  EXPECT_FLOAT_EQ(545237, easting);
-  EXPECT_FLOAT_EQ(3922415, northing);
+  EXPECT_FLOAT_EQ(545237.0, easting);
+  EXPECT_FLOAT_EQ(3922415.0, northing);
 
   utm_util.ToUtm(-54.843333, -68.295556, easting, northing);
-  EXPECT_FLOAT_EQ(545237, easting);
-  EXPECT_FLOAT_EQ(3922415, northing);
+  EXPECT_FLOAT_EQ(545237.0, easting);
+  EXPECT_FLOAT_EQ(3922415.0, northing);
 
-  // ADL 
+  // ADL
   utm_util.ToUtm(-34.945, 138.530556, zone, band, easting, northing);
   EXPECT_EQ(54, zone);
   EXPECT_EQ('H', band);
-  EXPECT_FLOAT_EQ(274484, easting);
-  EXPECT_FLOAT_EQ(6130272, northing);
+  EXPECT_NEAR(274484.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(6130272.0, northing);
 
   utm_util.ToUtm(-34.945, 138.530556, easting, northing);
-  EXPECT_FLOAT_EQ(274484, easting);
-  EXPECT_FLOAT_EQ(6130272, northing);
+  EXPECT_NEAR(274484.0, easting, 0.5);
+  EXPECT_FLOAT_EQ(6130272.0, northing);
 }
 
 TEST(UtmUtilTests, ToWgs84)
@@ -120,22 +120,22 @@ TEST(UtmUtilTests, ToWgs84)
   double lat, lon;
 
   // LAX
-  utm_util.ToLatLon(11, 'S', 369877, 3756673, lat, lon);
+  utm_util.ToLatLon(11, 'S', 369877.0, 3756673.0, lat, lon);
   EXPECT_FLOAT_EQ(33.9425, lat);
   EXPECT_NEAR(-118.408056, lon, .000005);
 
   // MIA
-  utm_util.ToLatLon(17, 'R', 571124, 2852989, lat, lon);
+  utm_util.ToLatLon(17, 'R', 571124.0, 2852989.0, lat, lon);
   EXPECT_FLOAT_EQ(25.793333, lat);
   EXPECT_NEAR(-80.290556, lon, .000005);
 
   // USH
-  utm_util.ToLatLon(19, 'F', 545237, 3922415, lat, lon);
+  utm_util.ToLatLon(19, 'F', 545237.0, 3922415.0, lat, lon);
   EXPECT_FLOAT_EQ(-54.843333, lat);
   EXPECT_FLOAT_EQ(-68.295556, lon);
 
   // ADL
-  utm_util.ToLatLon(54, 'H', 274484, 6130272, lat, lon);
+  utm_util.ToLatLon(54, 'H', 274484.0, 6130272.0, lat, lon);
   EXPECT_FLOAT_EQ(-34.945, lat);
   EXPECT_FLOAT_EQ(138.530556, lon);
 }
@@ -145,8 +145,8 @@ TEST(UtmUtilTests, Continuity)
   swri_transform_util::UtmUtil utm_util;
 
   // (FOR) - Fortaleza International Airport
-  double easting = 551940;
-  double northing = 9582637;
+  double easting = 551940.0;
+  double northing = 9582637.0;
 
   double last_lon = 0;
 


### PR DESCRIPTION
I made some changes to the use of `PROJ` in `utm_utils.cpp`, as a team member had noticed that there were problems with the `toLatLon()` calculations.

I also added the tests back in for ROS 2 (with some of this work having been done by @rjb0026). Some of the transform manager tests are failing, but the plan is that corrections to the relevant source code can be made in a separate PR.

In order to port the `initialize_origin` python tests to ROS 2, I installed a pip module and the external tf_transformations ROS 2 package so that the ROS 2 version of `quaternion_to_euler()` could be used. If we want to avoid such external dependencies, I can attempt to do those calculations another way. (This package also might only be available as of Humble, so it wouldn't work in EOL distros.)