### PR TITLE
Increase minimum CMake version to 3.16

### DIFF
--- a/marti_data_structures/CMakeLists.txt
+++ b/marti_data_structures/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(marti_data_structures)
 
 find_package(catkin REQUIRED)

--- a/swri_cli_tools/CMakeLists.txt
+++ b/swri_cli_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_cli_tools)
 
 set(RUN_DEPS

--- a/swri_console_util/CMakeLists.txt
+++ b/swri_console_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_console_util)
 
 find_package(catkin REQUIRED COMPONENTS roscpp)

--- a/swri_dbw_interface/CMakeLists.txt
+++ b/swri_dbw_interface/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_dbw_interface)
 
 find_package(catkin REQUIRED)

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(swri_geometry_util)
 

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_image_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_math_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_nodelet/CMakeLists.txt
+++ b/swri_nodelet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_nodelet)
 
 set(BUILD_DEPS 

--- a/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
+++ b/swri_nodelet/cmake/swri_nodelet-extras.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 set(swri_nodelet_SHARE ${swri_nodelet_PREFIX}/@CATKIN_PACKAGE_SHARE_DESTINATION@)
 

--- a/swri_opencv_util/CMakeLists.txt
+++ b/swri_opencv_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_opencv_util)
 
 find_package(catkin REQUIRED COMPONENTS cv_bridge swri_math_util)

--- a/swri_prefix_tools/CMakeLists.txt
+++ b/swri_prefix_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_prefix_tools)
 
 find_package(catkin REQUIRED)

--- a/swri_roscpp/CMakeLists.txt
+++ b/swri_roscpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(swri_roscpp)
 

--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake.em
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 set(swri_roscpp_SHARE ${swri_roscpp_PREFIX}/@CATKIN_PACKAGE_SHARE_DESTINATION@)
 

--- a/swri_rospy/CMakeLists.txt
+++ b/swri_rospy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(swri_rospy)
 

--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_route_util)
 
 set(BUILD_DEPS 

--- a/swri_serial_util/CMakeLists.txt
+++ b/swri_serial_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_serial_util)
 
 find_package(Boost REQUIRED)

--- a/swri_string_util/CMakeLists.txt
+++ b/swri_string_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(swri_string_util)
 

--- a/swri_system_util/CMakeLists.txt
+++ b/swri_system_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_system_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_transform_util)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.16)
 project(swri_yaml_util)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
When building with newer (CMake 3.28), the following warning will appear.
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This PR increases minimum CMake version to 3.16 to satisfy the compatibility check in newer CMake versions.

Note that Ubuntu focal (ROS Noetic) packages CMake 3.16.3, so this will be incompatible with the EOL ROS Melodic.