### PR TITLE
Replaced local projection math with geographiclib

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -43,6 +43,7 @@ if(NOT "${PROJ_FOUND}")
   )
 endif()
 
+# Geographiclib installs FindGeographicLib.cmake to this non-standard location
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
 find_package(GeographicLib REQUIRED)
 
@@ -79,13 +80,13 @@ target_link_libraries(${PROJECT_NAME}
   Boost::boost
   Boost::filesystem
   Boost::thread
+  ${GeographicLib_LIBRARIES}
   opencv_calib3d
   opencv_core
   opencv_highgui
   opencv_imgproc
   opencv_video
   ${PROJ_LIBRARIES}
-  ${GeographicLib_LIBRARIES}
   yaml-cpp
 )
 ament_target_dependencies(${PROJECT_NAME}

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -43,6 +43,9 @@ if(NOT "${PROJ_FOUND}")
   )
 endif()
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
+find_package(GeographicLib REQUIRED)
+
 add_library(${PROJECT_NAME} SHARED
   src/georeference.cpp
   src/local_xy_util.cpp
@@ -82,6 +85,7 @@ target_link_libraries(${PROJECT_NAME}
   opencv_imgproc
   opencv_video
   ${PROJ_LIBRARIES}
+  ${GeographicLib_LIBRARIES}
   yaml-cpp
 )
 ament_target_dependencies(${PROJECT_NAME}

--- a/swri_transform_util/include/swri_transform_util/local_xy_util.h
+++ b/swri_transform_util/include/swri_transform_util/local_xy_util.h
@@ -36,6 +36,8 @@
 #include <swri_transform_util/transform_util.h>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 
+#include "GeographicLib/LocalCartesian.hpp"
+
 namespace swri_transform_util
 {
 /**
@@ -215,13 +217,10 @@ namespace swri_transform_util
   protected:
     rclcpp::Node::SharedPtr node_;
 
-    double reference_latitude_;   //< Reference latitude in radians.
-    double reference_longitude_;  //< Reference longitude in radians.
     double reference_angle_;      //< Reference angle in radians ENU.
-    double reference_altitude_;   //< Reference altitude in meters.
 
-    double rho_lat_;
-    double rho_lon_;
+    GeographicLib::LocalCartesian local_cartesian_;
+
     double cos_angle_;
     double sin_angle_;
 

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -24,6 +24,7 @@
   <depend>diagnostic_updater</depend>
   <depend>geographic_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>geographiclib</depend>
   <depend>gps_msgs</depend>
   <depend>geos</depend>
   <depend>marti_nav_msgs</depend>

--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -161,7 +161,10 @@ namespace swri_transform_util
     if (!initialized_)
     {
       bool ignore_reference_angle = false;
-      node_->get_parameter_or("/local_xy_ignore_reference_angle", ignore_reference_angle, ignore_reference_angle);
+      if (node_)
+      {
+        node_->get_parameter_or("/local_xy_ignore_reference_angle", ignore_reference_angle, ignore_reference_angle);
+      }
 
       local_cartesian_.Reset(latitude, longitude, altitude);
 
@@ -193,7 +196,7 @@ namespace swri_transform_util
       cos_angle_ = std::cos(reference_angle_);
       sin_angle_ = std::sin(reference_angle_);
 
-      RCUTILS_LOG_WARN("LocalXyWgs84Util initializing origin to lat: %f, lon: %f, alt: %f", latitude, longitude, altitude);
+      RCUTILS_LOG_INFO("LocalXyWgs84Util initializing origin to lat: %f, lon: %f, alt: %f", latitude, longitude, altitude);
       
       pose_sub_.reset();
       initialized_ = true;

--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -102,28 +102,20 @@ namespace swri_transform_util
       double reference_altitude,
       rclcpp::Node::SharedPtr node) :
     node_(node),
-    reference_latitude_(reference_latitude * swri_math_util::_deg_2_rad),
-    reference_longitude_(reference_longitude * swri_math_util::_deg_2_rad),
     reference_angle_(reference_angle * swri_math_util::_deg_2_rad),
-    reference_altitude_(reference_altitude),
-    rho_lat_(0),
-    rho_lon_(0),
+    local_cartesian_(),
     cos_angle_(0),
     sin_angle_(0),
     frame_("map"),
     initialized_(false)
   {
-    Initialize();
+    HandleOrigin(reference_latitude, reference_longitude, reference_altitude, reference_angle, "map");
   }
 
   LocalXyWgs84Util::LocalXyWgs84Util(rclcpp::Node::SharedPtr node) :
     node_(node),
-    reference_latitude_(0),
-    reference_longitude_(0),
     reference_angle_(0),
-    reference_altitude_(0),
-    rho_lat_(0),
-    rho_lon_(0),
+    local_cartesian_(),
     cos_angle_(0),
     sin_angle_(0),
     frame_("map"),
@@ -148,23 +140,7 @@ namespace swri_transform_util
 
   void LocalXyWgs84Util::Initialize()
   {
-    reference_angle_ = swri_math_util::WrapRadians(reference_angle_, 0);
 
-    cos_angle_ = std::cos(reference_angle_);
-    sin_angle_ = std::sin(reference_angle_);
-
-    double depth = -reference_altitude_;
-
-    double p = _earth_eccentricity * std::sin(reference_latitude_);
-    p = 1.0 - p * p;
-
-    double rho_e = _earth_equator_radius *
-        (1.0 - _earth_eccentricity * _earth_eccentricity) / (std::sqrt(p) * p);
-    double rho_n = _earth_equator_radius / std::sqrt(p);
-
-    rho_lat_ = rho_e - depth;
-    rho_lon_ = (rho_n - depth) * std::cos(reference_latitude_);
-    initialized_ = true;
   }
 
   void LocalXyWgs84Util::HandlePoseStamped(const geometry_msgs::msg::PoseStamped::UniquePtr pose)
@@ -176,16 +152,18 @@ namespace swri_transform_util
         pose->header.frame_id);
   }
 
-  void LocalXyWgs84Util::HandleOrigin(double latitude, double longitude, double altitude, double angle, const std::string& frame_id)
+  void LocalXyWgs84Util::HandleOrigin(double latitude,
+                                      double longitude,
+                                      double altitude,
+                                      double angle,
+                                      std::string const &frame_id)
   {
     if (!initialized_)
     {
       bool ignore_reference_angle = false;
       node_->get_parameter_or("/local_xy_ignore_reference_angle", ignore_reference_angle, ignore_reference_angle);
 
-      reference_latitude_ = latitude * swri_math_util::_deg_2_rad;
-      reference_longitude_ = longitude * swri_math_util::_deg_2_rad;
-      reference_altitude_ = altitude;
+      local_cartesian_.Reset(latitude, longitude, altitude);
 
       if (!ignore_reference_angle)
       {
@@ -210,21 +188,26 @@ namespace swri_transform_util
       }
 
       frame_ = frame;
-      RCUTILS_LOG_WARN("LocalXyWgs84Util initializing origin to lat: %f, lon: %f, alt: %f", latitude, longitude, reference_altitude_);
-      Initialize();
+      reference_angle_ = swri_math_util::WrapRadians(reference_angle_, 0);
+
+      cos_angle_ = std::cos(reference_angle_);
+      sin_angle_ = std::sin(reference_angle_);
+
+      RCUTILS_LOG_WARN("LocalXyWgs84Util initializing origin to lat: %f, lon: %f, alt: %f", latitude, longitude, altitude);
+      
       pose_sub_.reset();
-      return;
+      initialized_ = true;
     }
   }
 
   double LocalXyWgs84Util::ReferenceLongitude() const
   {
-    return reference_longitude_ * swri_math_util::_rad_2_deg;
+    return local_cartesian_.LongitudeOrigin();
   }
 
   double LocalXyWgs84Util::ReferenceLatitude() const
   {
-    return reference_latitude_ * swri_math_util::_rad_2_deg;
+    return local_cartesian_.LatitudeOrigin();
   }
 
   double LocalXyWgs84Util::ReferenceAngle() const
@@ -234,7 +217,7 @@ namespace swri_transform_util
 
   double LocalXyWgs84Util::ReferenceAltitude() const
   {
-    return reference_altitude_;
+    return local_cartesian_.HeightOrigin();
   }
 
   bool LocalXyWgs84Util::ToLocalXy(
@@ -255,26 +238,12 @@ namespace swri_transform_util
         return false;
       }
 
-      double rlat = latitude * swri_math_util::_deg_2_rad;
-      double rlon = longitude * swri_math_util::_deg_2_rad;
-      double dLat = (rlat - reference_latitude_) * rho_lat_;
-      double dLon = (rlon - reference_longitude_);
-      // Check for case where the shortest distance crosses the antimeridian
-      if (dLon > swri_math_util::_pi)
-      {   
-        dLon -= swri_math_util::_2pi;
-      }   
-      
-      if (dLon < -swri_math_util::_pi)
-      {   
-        dLon += swri_math_util::_2pi;
-      }   
-        
-      dLon *= rho_lon_;
-  
+      double z, dLon, dLat;
+
+      local_cartesian_.Forward(latitude, longitude, 0, dLon, dLat, z);
+
       x =  cos_angle_ * dLon + sin_angle_ * dLat;
       y = -sin_angle_ * dLon + cos_angle_ * dLat;
-  
       return true;
     }
 
@@ -289,23 +258,12 @@ namespace swri_transform_util
   {
     if (initialized_)
     {
+      double alt;
       double dLon = cos_angle_ * x - sin_angle_ * y;
       double dLat = sin_angle_ * x + cos_angle_ * y;
-      double rlat = (dLat / rho_lat_) + reference_latitude_;
-      double rlon = (dLon / rho_lon_) + reference_longitude_;
 
-      latitude = rlat * swri_math_util::_rad_2_deg;
-      longitude = rlon * swri_math_util::_rad_2_deg;
-      // Constrain longitude in case it has wrapped across the date line
-      if (longitude >= 180.0)
-      {   
-        longitude -= 360.0;
-      }   
-        
-      if (longitude < -180.0)
-      {
-        longitude += 360.0;
-      }
+      local_cartesian_.Reverse(dLon, dLat, 0, latitude, longitude, alt);
+      return true;
     }
 
     return initialized_;

--- a/swri_transform_util/test/test_local_xy_util.cpp
+++ b/swri_transform_util/test/test_local_xy_util.cpp
@@ -63,8 +63,8 @@ TEST(LocalXyUtilTests, TestOffset1)
   EXPECT_NE(local_xy_util.ReferenceLatitude(), lat);
   EXPECT_NE(local_xy_util.ReferenceLongitude(), lon);
 
-  EXPECT_FLOAT_EQ(29.4937686007, lat);
-  EXPECT_FLOAT_EQ(-98.6134341407, lon);
+  EXPECT_FLOAT_EQ(29.4937684617, lat);
+  EXPECT_FLOAT_EQ(-98.6134340294, lon);
 
   double x2, y2;
   local_xy_util.ToLocalXy(lat, lon, x2, y2);
@@ -83,8 +83,8 @@ TEST(LocalXyUtilTests, TestOffset2)
   local_xy_util.ToWgs84(x, y, lat, lon);
   EXPECT_NE(local_xy_util.ReferenceLatitude(), lat);
   EXPECT_NE(local_xy_util.ReferenceLongitude(), lon);
-  EXPECT_FLOAT_EQ(29.4510874304, lat);
-  EXPECT_FLOAT_EQ(-98.6613942088, lon);
+  EXPECT_FLOAT_EQ(29.4510788901, lat);
+  EXPECT_FLOAT_EQ(-98.6613937867, lon);
 
   double x2, y2;
   local_xy_util.ToLocalXy(lat, lon, x2, y2);
@@ -140,15 +140,15 @@ TEST(LocalXyUtilTests, LocalXyFromWgs84)
       29.4937686007, -98.6134341407,
       29.45196669, -98.61370577,
       x, y);
-  EXPECT_FLOAT_EQ(26.3513, x);
-  EXPECT_FLOAT_EQ(4633.46, y);
+  EXPECT_FLOAT_EQ(26.3405, x);
+  EXPECT_FLOAT_EQ(4633.4741, y);
 
   swri_transform_util::LocalXyFromWgs84(
       29.4510874304, -98.6613942088,
       29.45196669, -98.61370577,
       x, y);
-  EXPECT_FLOAT_EQ(-4626.3513, x);
-  EXPECT_FLOAT_EQ(-97.46, y);
+  EXPECT_FLOAT_EQ(-4626.3906, x);
+  EXPECT_FLOAT_EQ(-96.5133, y);
 }
 
 TEST(LocalXyUtilTests, Wgs84FromLocalXy)
@@ -158,15 +158,15 @@ TEST(LocalXyUtilTests, Wgs84FromLocalXy)
       26.3513, 4633.46,
       29.45196669, -98.61370577,
       lat, lon);
-  EXPECT_FLOAT_EQ(29.4937686007, lat);
-  EXPECT_FLOAT_EQ(-98.6134341407, lon);
+  EXPECT_FLOAT_EQ(29.4937684617, lat);
+  EXPECT_FLOAT_EQ(-98.6134340294, lon);
 
   swri_transform_util::Wgs84FromLocalXy(
       -4626.3513, -97.46,
       29.45196669, -98.61370577,
       lat, lon);
-  EXPECT_FLOAT_EQ(29.4510874304, lat);
-  EXPECT_FLOAT_EQ(-98.6613942088, lon);
+  EXPECT_FLOAT_EQ(29.4510788901, lat);
+  EXPECT_FLOAT_EQ(-98.6613937867, lon);
 }
 
 TEST(LocalXyUtilTests, Continuity)
@@ -190,7 +190,7 @@ TEST(LocalXyUtilTests, Continuity)
     local_xy_util.ToLocalXy(new_lat, new_lon, new_x, new_y);
 
     EXPECT_FLOAT_EQ(x + i * 1.11 / 100.0, new_x);
-    EXPECT_FLOAT_EQ(y, new_y);
+    EXPECT_NEAR(y, new_y, 1e-9);
 
     if (i > 0)
     {

--- a/swri_transform_util/test/test_transform_util.cpp
+++ b/swri_transform_util/test/test_transform_util.cpp
@@ -47,8 +47,8 @@ TEST(TransformUtilTests, GetRelativeTransform)
                 );
 
   tf2::Vector3 origin = offset.getOrigin();
-  EXPECT_FLOAT_EQ(-8.47174665, origin.x());
-  EXPECT_FLOAT_EQ(-0.3306987, origin.y());
+  EXPECT_FLOAT_EQ(-8.47174634, origin.x());
+  EXPECT_FLOAT_EQ(-0.3306964, origin.y());
   EXPECT_FLOAT_EQ(0.0, origin.z());
 }
 


### PR DESCRIPTION
This change replaces the math uses for the local cartesian projection with GeographicLib's implementation. This means implementation is accurate over much longer distances and also brings it in line with implementation of robot_localization (https://github.com/cra-ros-pkg/robot_localization). This means that using a an swri_transform_util local cartesian transformation will return the same results as using the /{to,from}LL service provided by robot_localization.