### PR TITLE
Jazzy Pip Update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on: [push, pull_request]
+env:
+  PIP_BREAK_SYSTEM_PACKAGES: 1
 
 jobs:
   industrial_ci:
@@ -11,6 +13,8 @@ jobs:
           - {ROS_DISTRO: humble, ROS_REPO: main}
           - {ROS_DISTRO: iron, ROS_REPO: testing}
           - {ROS_DISTRO: iron, ROS_REPO: main}
+          - {ROS_DISTRO: jazzy, ROS_REPO: testing}
+          - {ROS_DISTRO: jazzy, ROS_REPO: main}
           - {ROS_DISTRO: rolling, ROS_REPO: testing}
           - {ROS_DISTRO: rolling, ROS_REPO: main}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Allows pip to break system packages to rosdep works on Jazzy and Rolling.