### PR TITLE
Remove transforms3d

### DIFF
--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -48,7 +48,6 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
-  <test_depend>python-transforms3d-pip</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/swri_transform_util/setup.py
+++ b/swri_transform_util/setup.py
@@ -13,6 +13,8 @@ setup(
     ],
     install_requires=['setuptools'],
     zip_safe=True,
+    maintainer='Southwest Research Institute',
+    maintainer_email='swri-robotics@swri.org'
     author='P. J. Reed',
     author_email='preed@swri.org',
     keywords=['ROS'],


### PR DESCRIPTION
Using transforms3d as a pure `pip` package causes problems because the ROS buildfarm cannot package pure `pip` dependencies, even if they are only test dependencies. This reimplements the math we need from transforms3d inside the test code.