### PR TITLE
Adding ros_environment Dependency

### DIFF
--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -14,6 +14,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>
+
   <depend>ament_index_cpp</depend>
   <depend>boost</depend>
   <depend>camera_calibration_parsers</depend>


### PR DESCRIPTION
Buildfarm builds are failing because ROS_DISTRO isn't set. This adds ros_environment as a build dependency to fix this problem.