### PR TITLE
Change Version Check Method

### DIFF
--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -109,7 +109,7 @@ ament_target_dependencies(${PROJECT_NAME}_nodes
 )
 
 # Iron and later switched some cv_bridge files to .hpp from .h
-if ("$ENV{ROS_DISTRO}" STRLESS "iron")
+if ("${cv_bridge_VERSION}" VERSION_LESS "3.3.0")
   target_compile_definitions(${PROJECT_NAME}_nodes PRIVATE "-DUSE_CVBRIDGE_H_FILES")
 endif()
 

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -14,8 +14,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <build_depend>ros_environment</build_depend>
-
   <depend>ament_index_cpp</depend>
   <depend>boost</depend>
   <depend>camera_calibration_parsers</depend>


### PR DESCRIPTION
Checking ROS_DISTRO on the buildfarm is causing problems, so this changes a version check to directly check cv_bridge's version number to decide whether to use .h or .hpp files, which should be much more robust.