### PR TITLE
Removing version check on Kinetic for C++ standard

### DIFF
--- a/swri_roscpp/CMakeLists.txt
+++ b/swri_roscpp/CMakeLists.txt
@@ -60,12 +60,7 @@ target_link_libraries(dynamic_parameters_test_node
   ${YamlCpp_LIBRARIES}
   Boost::thread
 )
-if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-  set_target_properties(dynamic_parameters_test_node PROPERTIES 
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED ON
-  )
-endif()
+target_compile_features(dynamic_parameters_test_node PUBLIC cxx_std_14)
 
 add_executable(subscriber_test src/nodes/subscriber_test.cpp)
 target_link_libraries(subscriber_test ${catkin_LIBRARIES})
@@ -99,11 +94,7 @@ if (CATKIN_ENABLE_TESTING)
     test/test_dynamic_parameters.test
     test/test_dynamic_parameters.cpp)
   target_link_libraries(test_dynamic_parameters ${catkin_LIBRARIES} ${YamlCpp_LIBRARIES})
-  if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-    set_target_properties(test_dynamic_parameters PROPERTIES 
-      CXX_STANDARD 11
-      CXX_STANDARD_REQUIRED ON)
-  endif()
+  target_compile_features(test_dynamic_parameters PUBLIC cxx_std_14)
 
   ### Test the TopicService server and client ###
   # This is a little different from the way tests are normally declared because we
@@ -125,12 +116,7 @@ if (CATKIN_ENABLE_TESTING)
     test/swri_node_handle_test.cpp
   )
   target_link_libraries(test_swri_node_handle ${catkin_LIBRARIES})
-  if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-    set_target_properties(test_swri_node_handle PROPERTIES 
-      CXX_STANDARD 11
-      CXX_STANDARD_REQUIRED ON
-    )
-  endif()
+  target_compile_features(test_swri_node_handle PUBLIC cxx_std_14)
 endif()
 
 ### Install Test Node and Headers ###

--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -39,12 +39,7 @@ add_library(${PROJECT_NAME}
   src/util.cpp
   src/visualization.cpp
   )
-if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-  set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED ON
-  )
-endif()
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${PROJECT_NAME}_boost

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -71,11 +71,7 @@ include_directories(SYSTEM
 )
 
 function(set_cxx_props targ)
-  if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-    set_target_properties(${targ} PROPERTIES
-      CXX_STANDARD 11
-      CXX_STANDARD_REQUIRED ON)
-  endif()
+  target_compile_features(${targ} PUBLIC cxx_std_14)
 endfunction()
 
 add_library(${PROJECT_NAME}

--- a/swri_yaml_util/CMakeLists.txt
+++ b/swri_yaml_util/CMakeLists.txt
@@ -38,15 +38,13 @@ include_directories(SYSTEM
 add_library(${PROJECT_NAME}
   src/yaml_util.cpp
 )
+
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${YamlCpp_LIBRARIES}
 )
-if ($ENV{ROS_DISTRO} STREQUAL "kinetic")
-  set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 11
-    CXX_STANDARD_REQUIRED ON)
-endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}


### PR DESCRIPTION
The lack of a `ros_environment` dependency was causing builds to fail on the buildfarm because of the check on the `ROS_DISTRO` environment variable in multiple packages. Since we have already made an unmaintained branch for Kinetic support, and the only supported is ever going to be ROS Noetic, I'm removing this check and always setting the C++ standard.