### PR TITLE
[kilted] Update deprecated calls to ament_target_dependencies

### DIFF
--- a/swri_console_util/CMakeLists.txt
+++ b/swri_console_util/CMakeLists.txt
@@ -8,8 +8,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED src/progress_bar.cpp)
-ament_target_dependencies(${PROJECT_NAME}
-  "rclcpp"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -31,15 +31,13 @@ target_include_directories(${PROJECT_NAME}
   $<INSTALL_INTERFACE:include>
   ${GEOS_INCLUDE_DIRS}
 )
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   geos_c
   Eigen3::Eigen
   opencv_core
-)
-ament_target_dependencies(${PROJECT_NAME}
-  "cv_bridge"
-  "rclcpp"
-  "tf2"
+  cv_bridge::cv_bridge
+  rclcpp::rclcpp
+  tf2::tf2
 )
 
 if(BUILD_TESTING)
@@ -57,11 +55,13 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(cv_bridge)

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(tf2 REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core stitching)
 
-find_package(Boost REQUIRED COMPONENTS filesystem system random)
+find_package(Boost REQUIRED COMPONENTS filesystem system random serialization thread)
 
 find_package(Eigen3 REQUIRED)
 add_definitions(${EIGEN3_DEFINITIONS})
@@ -45,7 +45,7 @@ target_include_directories(${PROJECT_NAME}
 )
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   Boost::boost
   Boost::filesystem
   Boost::random
@@ -53,25 +53,23 @@ target_link_libraries(${PROJECT_NAME}
   Eigen3::Eigen
   opencv_core
   opencv_stitching
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  camera_calibration_parsers::camera_calibration_parsers
+  cv_bridge::cv_bridge
+  image_geometry::image_geometry
+  image_transport::image_transport
+  message_filters::message_filters
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  swri_roscpp::swri_roscpp_library
+  swri_geometry_util::swri_geometry_util
+  swri_opencv_util::swri_opencv_util
+  tf2::tf2
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  camera_calibration_parsers
-  cv_bridge
-  geometry_msgs
-  image_geometry
-  image_transport
-  message_filters
-  nav_msgs
-  rclcpp
-  rclcpp_components
-  std_msgs
-  swri_geometry_util
-  swri_math_util
-  swri_opencv_util
-  swri_roscpp
-  tf2
-)
 
 add_library(${PROJECT_NAME}_nodes SHARED
   src/nodes/blend_images_node.cpp
@@ -103,9 +101,9 @@ rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::Normali
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::RotateImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::ScaleImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::WarpImageNode")
-target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
-ament_target_dependencies(${PROJECT_NAME}_nodes
-  ament_index_cpp
+target_link_libraries(${PROJECT_NAME}_nodes PUBLIC
+  ${PROJECT_NAME}
+  ament_index_cpp::ament_index_cpp
 )
 
 # Iron and later switched some cv_bridge files to .hpp from .h
@@ -125,11 +123,13 @@ install(DIRECTORY include/
 
 install(TARGETS ${PROJECT_NAME}
     ${PROJECT_NAME}_nodes
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+ament_export_targets(export_${PROJECT_NAME} export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}

--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -23,12 +23,10 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   Boost::boost
   Boost::random
-)
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
+  rclcpp::rclcpp
 )
 
 if(BUILD_TESTING)
@@ -49,11 +47,13 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
+        EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rclcpp)
 ament_export_include_directories(include ${rclcpp_INCLUDE_DIRS})

--- a/swri_opencv_util/CMakeLists.txt
+++ b/swri_opencv_util/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(swri_math_util REQUIRED)
 
 find_package(OpenCV REQUIRED core imgproc highgui)
 
-find_package(Boost REQUIRED COMPONENTS serialization thread) 
+find_package(Boost REQUIRED COMPONENTS serialization thread random)
   
 add_library(${PROJECT_NAME} SHARED
   src/blend.cpp
@@ -23,32 +23,32 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   Boost::boost
   Boost::serialization
   Boost::thread
   opencv_core
   opencv_imgproc
   opencv_highgui
+  cv_bridge::cv_bridge
+  swri_math_util::swri_math_util
 )
 
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
-ament_target_dependencies(${PROJECT_NAME}
-  cv_bridge
-  swri_math_util
-)
 
 install(DIRECTORY include/
   DESTINATION include
 )
 
 install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
+ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(cv_bridge)
 ament_export_dependencies(swri_math_util)

--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(swri_roscpp REQUIRED)
 find_package(swri_transform_util REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
+find_package(Boost COMPONENTS filesystem random thread)
 
 ### Build Library ###
 add_library(${PROJECT_NAME} SHARED
@@ -29,18 +30,16 @@ target_include_directories(${PROJECT_NAME}
 )
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-ament_target_dependencies(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME}
   PUBLIC
-  ament_cmake
-  marti_common_msgs
-  marti_nav_msgs
-  rclcpp
-  swri_geometry_util
-  swri_math_util
-  swri_roscpp
-  swri_transform_util
-  tf2_geometry_msgs
-  visualization_msgs
+  ${marti_common_msgs_TARGETS}
+  ${marti_nav_msgs_TARGETS}
+  ${visualization_msgs_TARGETS}
+  rclcpp::rclcpp
+  swri_geometry_util::swri_geometry_util
+  swri_roscpp::swri_roscpp_library
+  swri_transform_util::swri_transform_util
+  tf2_geometry_msgs::tf2_geometry_msgs
 )
 
 ### Install Libraries and Executables ###

--- a/swri_system_util/CMakeLists.txt
+++ b/swri_system_util/CMakeLists.txt
@@ -25,8 +25,7 @@ if(BUILD_TESTING)
 
   include_directories(${ament_index_cpp_INCLUDE_DIRS})
   ament_add_gtest(test_file_util test/test_file_util.cpp)
-  ament_target_dependencies(test_file_util ament_index_cpp)
-  target_link_libraries(test_file_util ${PROJECT_NAME})
+  target_link_libraries(test_file_util ${PROJECT_NAME} ament_index_cpp::ament_index_cpp)
 endif()
 
 install(DIRECTORY include/

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 find_package(yaml-cpp REQUIRED)
 find_package(OpenCV REQUIRED calib3d core highgui imgproc video)
-find_package(Boost REQUIRED filesystem thread)
+find_package(Boost REQUIRED filesystem thread random)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROJ proj)
@@ -88,21 +88,20 @@ target_link_libraries(${PROJECT_NAME}
   opencv_video
   ${PROJ_LIBRARIES}
   yaml-cpp
-)
-ament_target_dependencies(${PROJECT_NAME}
-  PUBLIC
-  diagnostic_msgs
-  diagnostic_updater
-  geographic_msgs
-  geometry_msgs
-  gps_msgs
-  rclcpp
-  sensor_msgs
-  swri_math_util
-  swri_roscpp
-  tf2
-  tf2_geometry_msgs
-  tf2_ros
+  ${diagnostic_msgs_TARGETS}
+  ${geographic_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${gps_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  diagnostic_updater::diagnostic_updater
+  geographic_msgs::validation
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
+  swri_math_util::swri_math_util
+  swri_roscpp::swri_roscpp_library
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
 )
 
 add_library(${PROJECT_NAME}_nodes SHARED
@@ -133,12 +132,13 @@ target_compile_definitions(${PROJECT_NAME}_nodes
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::DynamicTransformPublisher")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::GpsTransformPublisher")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::ObstacleTransformer")
-target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
-ament_target_dependencies(${PROJECT_NAME}_nodes
-  marti_nav_msgs
-  rcl_interfaces
-  swri_roscpp
-  rclcpp_components
+target_link_libraries(${PROJECT_NAME}_nodes PUBLIC
+  ${PROJECT_NAME}
+  ${marti_nav_msgs_TARGETS}
+  ${rcl_interfaces_TARGETS}
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  swri_roscpp::swri_roscpp_library
 )
 
 add_executable(lat_lon_tf_echo src/nodes/lat_lon_tf_echo.cpp)
@@ -163,24 +163,19 @@ if(BUILD_TESTING)
   target_include_directories(transform_manager_test PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   )
-  target_link_libraries(transform_manager_test ${PROJECT_NAME})
-  ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
+  target_link_libraries(transform_manager_test ${PROJECT_NAME} rclcpp::rclcpp tf2::tf2 tf2_ros::tf2_ros)
 
   ament_add_gtest(local_xy_util_test test/test_local_xy_util.cpp)
-  target_link_libraries(local_xy_util_test ${PROJECT_NAME})
-  ament_target_dependencies(local_xy_util_test rclcpp)
+  target_link_libraries(local_xy_util_test ${PROJECT_NAME} rclcpp::rclcpp)
 
   ament_add_gtest(utm_util_test test/test_utm_util.cpp)
-  target_link_libraries(utm_util_test ${PROJECT_NAME})
-  ament_target_dependencies(utm_util_test rclcpp)
+  target_link_libraries(utm_util_test ${PROJECT_NAME} rclcpp::rclcpp)
 
   ament_add_gtest(georeference_test test/test_georeference.cpp)
-  target_link_libraries(georeference_test ${PROJECT_NAME})
-  ament_target_dependencies(georeference_test rclcpp tf2 ament_index_cpp)
+  target_link_libraries(georeference_test ${PROJECT_NAME} ament_index_cpp::ament_index_cpp rclcpp::rclcpp tf2::tf2)
 
   ament_add_gtest(transform_util_test test/test_transform_util.cpp)
-  target_link_libraries(transform_util_test ${PROJECT_NAME})
-  ament_target_dependencies(transform_util_test rclcpp tf2)
+  target_link_libraries(transform_util_test ${PROJECT_NAME} rclcpp::rclcpp tf2::tf2)
 
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/local_xy_util.test.py)
@@ -218,6 +213,7 @@ install(TARGETS
   ${PROJECT_NAME}
   ${PROJECT_NAME}_nodes
   lat_lon_tf_echo
+  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -228,6 +224,7 @@ install(PROGRAMS nodes/initialize_origin.py
   DESTINATION lib/${PROJECT_NAME}
 )
 
+ament_export_targets(export_${PROJECT_NAME} export_${PROJECT_NAME})
 ament_python_install_package(${PROJECT_NAME})
 ament_export_definitions("${TF_UTIL_DEFINITIONS}")
 ament_export_dependencies(


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: There's a lot of changes in this PR, and I'm not 100% certain on them all, but it did get things to successfully compile on my machine. 