### PR TITLE
WIP: Rolling Updates

### DIFF
--- a/swri_console_util/CMakeLists.txt
+++ b/swri_console_util/CMakeLists.txt
@@ -8,9 +8,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED src/progress_bar.cpp)
-ament_target_dependencies(${PROJECT_NAME}
-  "rclcpp"
-)
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(GEOS REQUIRED)
 
 find_package(OpenCV REQUIRED core)
 
-find_package(Eigen3 REQUIRED)
+find_package(Eigen3 REQUIRED NO_MODULE)
 
 add_library(${PROJECT_NAME} SHARED
   src/cubic_spline.cpp
@@ -31,16 +31,14 @@ target_include_directories(${PROJECT_NAME}
   $<INSTALL_INTERFACE:include>
   ${GEOS_INCLUDE_DIRS}
 )
-target_link_libraries(${PROJECT_NAME}
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  cv_bridge::cv_bridge
   geos_c
   Eigen3::Eigen
   opencv_core
-)
-ament_target_dependencies(${PROJECT_NAME}
-  "cv_bridge"
-  "rclcpp"
-  "tf2"
-)
+  rclcpp::rclcpp
+  tf2::tf2)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -5,13 +5,16 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem system random)
 find_package(camera_calibration_parsers REQUIRED)
 find_package(cv_bridge REQUIRED)
+find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(image_geometry REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(nav_msgs REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core stitching)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclpy REQUIRED)
@@ -22,11 +25,6 @@ find_package(swri_opencv_util REQUIRED)
 find_package(swri_roscpp REQUIRED)
 find_package(tf2 REQUIRED)
 
-find_package(OpenCV REQUIRED COMPONENTS core stitching)
-
-find_package(Boost REQUIRED COMPONENTS filesystem system random)
-
-find_package(Eigen3 REQUIRED)
 add_definitions(${EIGEN3_DEFINITIONS})
 
 add_library(${PROJECT_NAME} SHARED
@@ -40,38 +38,36 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${swri_opencv_util_INCLUDE_DIRS})
+
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(${PROJECT_NAME}
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${geometry_msgs_TARGETS}
+  ${nav_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${swri_opencv_util_TARGETS}
+  ${swri_roscpp_TARGETS}
   Boost::boost
   Boost::filesystem
   Boost::random
   Boost::system
+  camera_calibration_parsers::camera_calibration_parsers
+  cv_bridge::cv_bridge
   Eigen3::Eigen
+  image_geometry::image_geometry
+  image_transport::image_transport
+  message_filters::message_filters
   opencv_core
   opencv_stitching
-)
-
-ament_target_dependencies(${PROJECT_NAME}
-  camera_calibration_parsers
-  cv_bridge
-  geometry_msgs
-  image_geometry
-  image_transport
-  message_filters
-  nav_msgs
-  rclcpp
-  rclcpp_components
-  std_msgs
-  swri_geometry_util
-  swri_math_util
-  swri_opencv_util
-  swri_roscpp
-  tf2
-)
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_components::component_manager
+  swri_roscpp::swri_roscpp_library
+  tf2::tf2)
 
 add_library(${PROJECT_NAME}_nodes SHARED
   src/nodes/blend_images_node.cpp
@@ -103,9 +99,9 @@ rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::Normali
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::RotateImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::ScaleImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::WarpImageNode")
-target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
-ament_target_dependencies(${PROJECT_NAME}_nodes
-  ament_index_cpp
+target_link_libraries(${PROJECT_NAME}_nodes
+  ${PROJECT_NAME}
+  ament_index_cpp::ament_index_cpp
 )
 
 # Iron and later switched some cv_bridge files to .hpp from .h

--- a/swri_image_util/include/swri_image_util/geometry_util.h
+++ b/swri_image_util/include/swri_image_util/geometry_util.h
@@ -24,8 +24,8 @@
 
 #include <opencv2/core/core.hpp>
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/image_warp_util.cpp
+++ b/swri_image_util/src/image_warp_util.cpp
@@ -27,14 +27,11 @@
 //
 // *****************************************************************************
 
+#include <algorithm>
+#include <chrono>
+#include <rclcpp/logging.hpp>
 #include <swri_image_util/image_warp_util.h>
 #include <swri_opencv_util/model_fit.h>
-
-#include <algorithm>
-
-#include <rclcpp/logging.hpp>
-
-#include <chrono>
 
 namespace swri_image_util
 {

--- a/swri_image_util/test/test_geometry_util.cpp
+++ b/swri_image_util/test/test_geometry_util.cpp
@@ -35,7 +35,7 @@
 
 #include <opencv2/core/core.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 
 #include <swri_math_util/constants.h>
 #include <swri_image_util/geometry_util.h>

--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -20,16 +20,12 @@ set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME}
   Boost::boost
   Boost::random
-)
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-)
+  rclcpp::rclcpp)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/swri_opencv_util/CMakeLists.txt
+++ b/swri_opencv_util/CMakeLists.txt
@@ -4,13 +4,10 @@ project(swri_opencv_util)
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake REQUIRED)
-
-find_package(cv_bridge REQUIRED)
-find_package(swri_math_util REQUIRED)
-
-find_package(OpenCV REQUIRED core imgproc highgui)
-
 find_package(Boost REQUIRED COMPONENTS serialization thread) 
+find_package(cv_bridge REQUIRED)
+find_package(OpenCV REQUIRED core imgproc highgui)
+find_package(swri_math_util REQUIRED)
   
 add_library(${PROJECT_NAME} SHARED
   src/blend.cpp
@@ -20,24 +17,25 @@ add_library(${PROJECT_NAME} SHARED
   src/convert.cpp)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
-)
-target_link_libraries(${PROJECT_NAME}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    ${swri_math_util_INCLUDE_DIRS})
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
   Boost::boost
   Boost::serialization
   Boost::thread
+  cv_bridge::cv_bridge
   opencv_core
   opencv_imgproc
-  opencv_highgui
-)
+  opencv_highgui)
+
+#ament_target_dependencies(${PROJECT_NAME}
+#  cv_bridge
+#  swri_math_util)
 
 set_property(TARGET ${PROJECT_NAME}
   PROPERTY POSITION_INDEPENDENT_CODE ON)
-ament_target_dependencies(${PROJECT_NAME}
-  cv_bridge
-  swri_math_util
-)
 
 install(DIRECTORY include/
   DESTINATION include

--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.10)
 
 set(swri_roscpp_BIN "${swri_roscpp_DIR}/../../../bin/")
 

--- a/swri_system_util/CMakeLists.txt
+++ b/swri_system_util/CMakeLists.txt
@@ -25,8 +25,9 @@ if(BUILD_TESTING)
 
   include_directories(${ament_index_cpp_INCLUDE_DIRS})
   ament_add_gtest(test_file_util test/test_file_util.cpp)
-  ament_target_dependencies(test_file_util ament_index_cpp)
-  target_link_libraries(test_file_util ${PROJECT_NAME})
+  target_link_libraries(test_file_util
+    ament_index_cpp::ament_index_cpp
+    ${PROJECT_NAME})
 endif()
 
 install(DIRECTORY include/

--- a/swri_system_util/src/file_util.cpp
+++ b/swri_system_util/src/file_util.cpp
@@ -165,9 +165,9 @@ namespace swri_system_util
     boost::filesystem::recursive_directory_iterator end_it;
     while (it != end_it)
     {
-      if (max_depth >= 0 && it.level() >= max_depth)
+      if (max_depth >= 0 && it.depth() >= max_depth)
       {
-        it.no_push();
+        it.disable_recursion_pending();
       }
 
       boost::smatch what;

--- a/swri_transform_util/include/swri_transform_util/transform.h
+++ b/swri_transform_util/include/swri_transform_util/transform.h
@@ -37,10 +37,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/include/swri_transform_util/transform_manager.h
+++ b/swri_transform_util/include/swri_transform_util/transform_manager.h
@@ -40,7 +40,7 @@
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/swri_transform_util/include/swri_transform_util/transform_util.h
+++ b/swri_transform_util/include/swri_transform_util/transform_util.h
@@ -33,11 +33,11 @@
 #include <string>
 #include <array>
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/include/swri_transform_util/transformer.h
+++ b/swri_transform_util/include/swri_transform_util/transformer.h
@@ -38,7 +38,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/swri_transform_util/include/swri_transform_util/utm_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/utm_transformer.h
@@ -36,7 +36,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 
 #include <swri_transform_util/utm_util.h>

--- a/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
@@ -34,7 +34,7 @@
 #include <string>
 #include <vector>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/buffer.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 

--- a/swri_transform_util/src/nodes/dynamic_transform_publisher.cpp
+++ b/swri_transform_util/src/nodes/dynamic_transform_publisher.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2017-2025, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,10 +37,10 @@
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/test/test_transform_manager.cpp
+++ b/swri_transform_util/test/test_transform_manager.cpp
@@ -34,7 +34,7 @@
 #include <thread>
 
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 
 #include <swri_transform_util/transform_manager.h>
 #include <swri_transform_util/frames.h>


### PR DESCRIPTION
Removes deprecated header files and updates CMakeLists to remove ament_target_dependencies() calls.