### PR TITLE
Reverting changes back to 3.7.4

### DIFF
--- a/swri_console_util/CMakeLists.txt
+++ b/swri_console_util/CMakeLists.txt
@@ -8,9 +8,9 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED src/progress_bar.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  rclcpp::rclcpp)
-
+ament_target_dependencies(${PROJECT_NAME}
+  "rclcpp"
+)
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/swri_geometry_util/CMakeLists.txt
+++ b/swri_geometry_util/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(GEOS REQUIRED)
 
 find_package(OpenCV REQUIRED core)
 
-find_package(Eigen3 REQUIRED NO_MODULE)
+find_package(Eigen3 REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/cubic_spline.cpp
@@ -31,14 +31,16 @@ target_include_directories(${PROJECT_NAME}
   $<INSTALL_INTERFACE:include>
   ${GEOS_INCLUDE_DIRS}
 )
-
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  cv_bridge::cv_bridge
+target_link_libraries(${PROJECT_NAME}
   geos_c
   Eigen3::Eigen
   opencv_core
-  rclcpp::rclcpp
-  tf2::tf2)
+)
+ament_target_dependencies(${PROJECT_NAME}
+  "cv_bridge"
+  "rclcpp"
+  "tf2"
+)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -55,13 +57,11 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
-ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(cv_bridge)

--- a/swri_geometry_util/include/swri_geometry_util/cubic_spline.h
+++ b/swri_geometry_util/include/swri_geometry_util/cubic_spline.h
@@ -32,8 +32,8 @@
 
 #include <vector>
 #include <opencv2/core/core.hpp>
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Vector3.h>
 
 namespace swri_geometry_util
 {

--- a/swri_geometry_util/include/swri_geometry_util/geometry_util.h
+++ b/swri_geometry_util/include/swri_geometry_util/geometry_util.h
@@ -31,8 +31,8 @@
 #define SWRI_GEOMETRY_UTIL_GEOMETRY_UTIL_H_
 
 #include <opencv2/core/core.hpp>
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Vector3.h>
 
 namespace swri_geometry_util
 {

--- a/swri_image_util/CMakeLists.txt
+++ b/swri_image_util/CMakeLists.txt
@@ -5,16 +5,13 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem system random)
 find_package(camera_calibration_parsers REQUIRED)
 find_package(cv_bridge REQUIRED)
-find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(image_geometry REQUIRED)
 find_package(image_transport REQUIRED)
 find_package(message_filters REQUIRED)
 find_package(nav_msgs REQUIRED)
-find_package(OpenCV REQUIRED COMPONENTS core stitching)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rclpy REQUIRED)
@@ -27,7 +24,7 @@ find_package(tf2 REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core stitching)
 
-find_package(Boost REQUIRED COMPONENTS filesystem system random serialization thread)
+find_package(Boost REQUIRED COMPONENTS filesystem system random)
 
 find_package(Eigen3 REQUIRED)
 add_definitions(${EIGEN3_DEFINITIONS})
@@ -43,47 +40,38 @@ add_library(${PROJECT_NAME} SHARED
 )
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${swri_geometry_util_INCLUDE_DIRS}
-    ${swri_opencv_util_INCLUDE_DIRS})
-
-target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${geometry_msgs_TARGETS}
-  ${nav_msgs_TARGETS}
-  ${std_msgs_TARGETS}
-  ${swri_geometry_util_LIBRARIES}
-  ${swri_opencv_util_LIBRARIES}
-  ${swri_roscpp_LIBRARIES}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+set_property(TARGET ${PROJECT_NAME}
+  PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(${PROJECT_NAME}
   Boost::boost
   Boost::filesystem
   Boost::random
   Boost::system
-  camera_calibration_parsers::camera_calibration_parsers
-  cv_bridge::cv_bridge
   Eigen3::Eigen
-  image_geometry::image_geometry
-  image_transport::image_transport
-  message_filters::message_filters
   opencv_core
   opencv_stitching
-  ${geometry_msgs_TARGETS}
-  ${nav_msgs_TARGETS}
-  ${std_msgs_TARGETS}
-  camera_calibration_parsers::camera_calibration_parsers
-  cv_bridge::cv_bridge
-  image_geometry::image_geometry
-  image_transport::image_transport
-  message_filters::message_filters
-  rclcpp::rclcpp
-  rclcpp_components::component
-  rclcpp_components::component_manager
-  swri_roscpp::swri_roscpp_library
-  swri_geometry_util::swri_geometry_util
-  swri_opencv_util::swri_opencv_util
-  tf2::tf2
 )
 
+ament_target_dependencies(${PROJECT_NAME}
+  camera_calibration_parsers
+  cv_bridge
+  geometry_msgs
+  image_geometry
+  image_transport
+  message_filters
+  nav_msgs
+  rclcpp
+  rclcpp_components
+  std_msgs
+  swri_geometry_util
+  swri_math_util
+  swri_opencv_util
+  swri_roscpp
+  tf2
+)
 
 add_library(${PROJECT_NAME}_nodes SHARED
   src/nodes/blend_images_node.cpp
@@ -115,9 +103,9 @@ rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::Normali
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::RotateImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::ScaleImageNode")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_image_util::WarpImageNode")
-target_link_libraries(${PROJECT_NAME}_nodes PUBLIC
-  ${PROJECT_NAME}
-  ament_index_cpp::ament_index_cpp
+target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
+ament_target_dependencies(${PROJECT_NAME}_nodes
+  ament_index_cpp
 )
 
 # Iron and later switched some cv_bridge files to .hpp from .h
@@ -137,13 +125,11 @@ install(DIRECTORY include/
 
 install(TARGETS ${PROJECT_NAME}
     ${PROJECT_NAME}_nodes
-  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
-ament_export_targets(export_${PROJECT_NAME} export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}

--- a/swri_image_util/include/swri_image_util/geometry_util.h
+++ b/swri_image_util/include/swri_image_util/geometry_util.h
@@ -24,8 +24,8 @@
 
 #include <opencv2/core/core.hpp>
 
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Vector3.h>
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/image_warp_util.cpp
+++ b/swri_image_util/src/image_warp_util.cpp
@@ -27,11 +27,14 @@
 //
 // *****************************************************************************
 
-#include <algorithm>
-#include <chrono>
-#include <rclcpp/logging.hpp>
 #include <swri_image_util/image_warp_util.h>
 #include <swri_opencv_util/model_fit.h>
+
+#include <algorithm>
+
+#include <rclcpp/logging.hpp>
+
+#include <chrono>
 
 namespace swri_image_util
 {

--- a/swri_image_util/src/nodes/blend_images_node.cpp
+++ b/swri_image_util/src/nodes/blend_images_node.cpp
@@ -36,10 +36,9 @@
 #include <cv_bridge/cv_bridge.hpp>
 #endif
 #include <image_transport/image_transport.hpp>
-#include <image_transport/subscriber_filter.hpp>
-#include <message_filters/subscriber.hpp>
-#include <message_filters/time_synchronizer.hpp>
-#include <message_filters/sync_policies/approximate_time.hpp>
+#include <message_filters/subscriber.h>
+#include <message_filters/time_synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
 #include <sensor_msgs/msg/image.hpp>
 #include <swri_opencv_util/blend.h>
 
@@ -71,8 +70,8 @@ namespace swri_image_util
     // Publishes the blended image
     image_transport::Publisher image_pub_;
     // The subscribers for the base and top image
-    image_transport::SubscriberFilter base_image_sub_;
-    image_transport::SubscriberFilter top_image_sub_;
+    message_filters::Subscriber<sensor_msgs::msg::Image> base_image_sub_;
+    message_filters::Subscriber<sensor_msgs::msg::Image> top_image_sub_;
     // Synchronization object for the two images we need for the blending
     // process
     std::shared_ptr<ApproximateTimeSync> image_sync_;
@@ -114,22 +113,8 @@ namespace swri_image_util
     this->declare_parameter("mask_b", -1.0, rgbDesc);
 
     image_pub_ = image_transport::create_publisher(this, "blended_image");
-    const auto sensor_data_qos = rclcpp::SensorDataQoS();
-    image_transport::TransportHints hints(this);
-    auto sub_opts = rclcpp::SubscriptionOptions();
-    sub_opts.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
-    base_image_sub_.subscribe(
-      this,
-      "base_image",
-      hints.getTransport(),
-      sensor_data_qos.get_rmw_qos_profile(),
-      sub_opts);
-    top_image_sub_.subscribe(
-      this,
-      "top_image",
-      hints.getTransport(),
-      sensor_data_qos.get_rmw_qos_profile(),
-      sub_opts);
+    base_image_sub_.subscribe(this, "base_image");
+    top_image_sub_.subscribe(this, "top_image");
     image_sync_.reset(new ApproximateTimeSync(
         ApproximateTimePolicy(10),
         base_image_sub_,

--- a/swri_image_util/test/test_geometry_util.cpp
+++ b/swri_image_util/test/test_geometry_util.cpp
@@ -35,7 +35,7 @@
 
 #include <opencv2/core/core.hpp>
 
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 
 #include <swri_math_util/constants.h>
 #include <swri_image_util/geometry_util.h>

--- a/swri_math_util/CMakeLists.txt
+++ b/swri_math_util/CMakeLists.txt
@@ -23,10 +23,12 @@ target_include_directories(${PROJECT_NAME}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(${PROJECT_NAME} PUBLIC
+target_link_libraries(${PROJECT_NAME}
   Boost::boost
   Boost::random
-  rclcpp::rclcpp
+)
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
 )
 
 if(BUILD_TESTING)
@@ -47,13 +49,11 @@ install(DIRECTORY include/
 )
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
 
-ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rclcpp)
 ament_export_include_directories(include ${rclcpp_INCLUDE_DIRS})

--- a/swri_opencv_util/CMakeLists.txt
+++ b/swri_opencv_util/CMakeLists.txt
@@ -4,10 +4,13 @@ project(swri_opencv_util)
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(ament_cmake REQUIRED)
-find_package(Boost REQUIRED COMPONENTS serialization thread random)
+
 find_package(cv_bridge REQUIRED)
+find_package(swri_math_util REQUIRED)
+
 find_package(OpenCV REQUIRED core imgproc highgui)
-find_package(swri_math_util)
+
+find_package(Boost REQUIRED COMPONENTS serialization thread) 
   
 add_library(${PROJECT_NAME} SHARED
   src/blend.cpp
@@ -19,28 +22,33 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
-  ${swri_math_util_INCLUDE_DIRS})
-
-target_link_libraries(${PROJECT_NAME} PUBLIC
+)
+target_link_libraries(${PROJECT_NAME}
   Boost::boost
   Boost::serialization
   Boost::thread
-  cv_bridge::cv_bridge
   opencv_core
   opencv_imgproc
   opencv_highgui
-  ${swri_math_util_LIBRARIES})
+)
+
+set_property(TARGET ${PROJECT_NAME}
+  PROPERTY POSITION_INDEPENDENT_CODE ON)
+ament_target_dependencies(${PROJECT_NAME}
+  cv_bridge
+  swri_math_util
+)
 
 install(DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include
+)
 
 install(TARGETS ${PROJECT_NAME}
-  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  ARCHIVE DESTINATION lib
+)
 
-ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(cv_bridge)
 ament_export_dependencies(swri_math_util)

--- a/swri_roscpp/cmake/swri_roscpp-extras.cmake
+++ b/swri_roscpp/cmake/swri_roscpp-extras.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.0.2)
 
 set(swri_roscpp_BIN "${swri_roscpp_DIR}/../../../bin/")
 

--- a/swri_route_util/CMakeLists.txt
+++ b/swri_route_util/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(swri_roscpp REQUIRED)
 find_package(swri_transform_util REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
-find_package(Boost COMPONENTS filesystem random thread)
 
 ### Build Library ###
 add_library(${PROJECT_NAME} SHARED
@@ -30,16 +29,18 @@ target_include_directories(${PROJECT_NAME}
 )
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(${PROJECT_NAME}
+ament_target_dependencies(${PROJECT_NAME}
   PUBLIC
-  ${marti_common_msgs_TARGETS}
-  ${marti_nav_msgs_TARGETS}
-  ${visualization_msgs_TARGETS}
-  rclcpp::rclcpp
-  swri_geometry_util::swri_geometry_util
-  swri_roscpp::swri_roscpp_library
-  swri_transform_util::swri_transform_util
-  tf2_geometry_msgs::tf2_geometry_msgs
+  ament_cmake
+  marti_common_msgs
+  marti_nav_msgs
+  rclcpp
+  swri_geometry_util
+  swri_math_util
+  swri_roscpp
+  swri_transform_util
+  tf2_geometry_msgs
+  visualization_msgs
 )
 
 ### Install Libraries and Executables ###

--- a/swri_route_util/include/swri_route_util/route_point.h
+++ b/swri_route_util/include/swri_route_util/route_point.h
@@ -32,8 +32,8 @@
 #include <string>
 #include <map>
 
-#include <tf2/LinearMath/Vector3.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>

--- a/swri_route_util/include/swri_route_util/route_speeds.h
+++ b/swri_route_util/include/swri_route_util/route_speeds.h
@@ -37,7 +37,7 @@
 #include <swri_math_util/interpolation_1d.h>
 #include <swri_route_util/route.h>
 #include <swri_transform_util/transform.h>
-#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Vector3.h>
 
 namespace swri_route_util
 {

--- a/swri_system_util/CMakeLists.txt
+++ b/swri_system_util/CMakeLists.txt
@@ -25,13 +25,13 @@ if(BUILD_TESTING)
 
   include_directories(${ament_index_cpp_INCLUDE_DIRS})
   ament_add_gtest(test_file_util test/test_file_util.cpp)
-  target_link_libraries(test_file_util
-    ament_index_cpp::ament_index_cpp
-    ${PROJECT_NAME})
+  ament_target_dependencies(test_file_util ament_index_cpp)
+  target_link_libraries(test_file_util ${PROJECT_NAME})
+endif()
 
 install(DIRECTORY include/
-  DESTINATION include)
-endif()
+  DESTINATION include
+)
 
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin

--- a/swri_system_util/src/file_util.cpp
+++ b/swri_system_util/src/file_util.cpp
@@ -165,9 +165,9 @@ namespace swri_system_util
     boost::filesystem::recursive_directory_iterator end_it;
     while (it != end_it)
     {
-      if (max_depth >= 0 && it.depth() >= max_depth)
+      if (max_depth >= 0 && it.level() >= max_depth)
       {
-        it.disable_recursion_pending();
+        it.no_push();
       }
 
       boost::smatch what;

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 find_package(yaml-cpp REQUIRED)
 find_package(OpenCV REQUIRED calib3d core highgui imgproc video)
-find_package(Boost REQUIRED filesystem thread random)
+find_package(Boost REQUIRED filesystem thread)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PROJ proj)
@@ -58,17 +58,18 @@ add_library(${PROJECT_NAME} SHARED
   src/tf2_util.cpp
   src/utm_transformer.cpp
   src/wgs84_transformer.cpp)
-
 target_include_directories(${PROJECT_NAME}
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-    ${swri_math_util_INCLUDE_DIRS}
-    ${tf2_geometry_msgs_INCLUDE_DIRS}
-  INTERFACE
-    ${PROJ_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
 )
-
+target_include_directories(${PROJECT_NAME}
+  SYSTEM
+  INTERFACE
+  ${PROJ_INCLUDE_DIRS}
+)
+set_property(TARGET ${PROJECT_NAME}
+  PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_compile_definitions(${PROJECT_NAME}
   PUBLIC
     USE_NEW_TF2_TOMSG=${USE_NEW_TF2_TOMSG}
@@ -87,20 +88,21 @@ target_link_libraries(${PROJECT_NAME}
   opencv_video
   ${PROJ_LIBRARIES}
   yaml-cpp
-  ${diagnostic_msgs_TARGETS}
-  ${geographic_msgs_TARGETS}
-  ${geometry_msgs_TARGETS}
-  ${gps_msgs_TARGETS}
-  ${sensor_msgs_TARGETS}
-  diagnostic_updater::diagnostic_updater
-  geographic_msgs::validation
-  rclcpp::rclcpp
-  sensor_msgs::sensor_msgs_library
-  swri_math_util::swri_math_util
-  swri_roscpp::swri_roscpp_library
-  tf2::tf2
-  tf2_geometry_msgs::tf2_geometry_msgs
-  tf2_ros::tf2_ros
+)
+ament_target_dependencies(${PROJECT_NAME}
+  PUBLIC
+  diagnostic_msgs
+  diagnostic_updater
+  geographic_msgs
+  geometry_msgs
+  gps_msgs
+  rclcpp
+  sensor_msgs
+  swri_math_util
+  swri_roscpp
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
 )
 
 add_library(${PROJECT_NAME}_nodes SHARED
@@ -113,40 +115,43 @@ target_include_directories(${PROJECT_NAME}_nodes
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-
 target_include_directories(${PROJECT_NAME}_nodes
   SYSTEM
   INTERFACE
-  ${PROJ_INCLUDE_DIRS})
+  ${PROJ_INCLUDE_DIRS}
+)
 
 target_compile_definitions(${PROJECT_NAME}
-  PUBLIC "${TF_UTIL_DEFINITIONS}")
-
+  PUBLIC "${TF_UTIL_DEFINITIONS}"
+  )
 target_compile_definitions(${PROJECT_NAME}_nodes
-  PRIVATE "${TF_UTIL_DEFINITIONS}")
+  PRIVATE "${TF_UTIL_DEFINITIONS}"
+  )
 
 target_compile_definitions(${PROJECT_NAME}_nodes
   PRIVATE "COMPOSITION_BUILDING_DLL")
-
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::DynamicTransformPublisher")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::GpsTransformPublisher")
 rclcpp_components_register_nodes(${PROJECT_NAME}_nodes "swri_transform_util::ObstacleTransformer")
-target_link_libraries(${PROJECT_NAME}_nodes PUBLIC
-  ${PROJECT_NAME}
-  ${marti_nav_msgs_TARGETS}
-  ${rcl_interfaces_TARGETS}
-  rclcpp_components::component
-  rclcpp_components::component_manager
-  swri_roscpp::swri_roscpp_library
+target_link_libraries(${PROJECT_NAME}_nodes ${PROJECT_NAME})
+ament_target_dependencies(${PROJECT_NAME}_nodes
+  marti_nav_msgs
+  rcl_interfaces
+  swri_roscpp
+  rclcpp_components
 )
 
 add_executable(lat_lon_tf_echo src/nodes/lat_lon_tf_echo.cpp)
 target_include_directories(lat_lon_tf_echo
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+target_include_directories(lat_lon_tf_echo
+  SYSTEM
   INTERFACE
-  ${PROJ_INCLUDE_DIRS})
+  ${PROJ_INCLUDE_DIRS}
+)
 
 target_link_libraries(lat_lon_tf_echo ${PROJECT_NAME})
 
@@ -158,19 +163,24 @@ if(BUILD_TESTING)
   target_include_directories(transform_manager_test PRIVATE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   )
-  target_link_libraries(transform_manager_test ${PROJECT_NAME} rclcpp::rclcpp tf2::tf2 tf2_ros::tf2_ros)
+  target_link_libraries(transform_manager_test ${PROJECT_NAME})
+  ament_target_dependencies(transform_manager_test rclcpp tf2 tf2_ros)
 
   ament_add_gtest(local_xy_util_test test/test_local_xy_util.cpp)
-  target_link_libraries(local_xy_util_test ${PROJECT_NAME} rclcpp::rclcpp)
+  target_link_libraries(local_xy_util_test ${PROJECT_NAME})
+  ament_target_dependencies(local_xy_util_test rclcpp)
 
   ament_add_gtest(utm_util_test test/test_utm_util.cpp)
-  target_link_libraries(utm_util_test ${PROJECT_NAME} rclcpp::rclcpp)
+  target_link_libraries(utm_util_test ${PROJECT_NAME})
+  ament_target_dependencies(utm_util_test rclcpp)
 
   ament_add_gtest(georeference_test test/test_georeference.cpp)
-  target_link_libraries(georeference_test ${PROJECT_NAME} ament_index_cpp::ament_index_cpp rclcpp::rclcpp tf2::tf2)
+  target_link_libraries(georeference_test ${PROJECT_NAME})
+  ament_target_dependencies(georeference_test rclcpp tf2 ament_index_cpp)
 
   ament_add_gtest(transform_util_test test/test_transform_util.cpp)
-  target_link_libraries(transform_util_test ${PROJECT_NAME} rclcpp::rclcpp tf2::tf2)
+  target_link_libraries(transform_util_test ${PROJECT_NAME})
+  ament_target_dependencies(transform_util_test rclcpp tf2)
 
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/local_xy_util.test.py)
@@ -208,7 +218,6 @@ install(TARGETS
   ${PROJECT_NAME}
   ${PROJECT_NAME}_nodes
   lat_lon_tf_echo
-  EXPORT export_${PROJECT_NAME}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -219,7 +228,6 @@ install(PROGRAMS nodes/initialize_origin.py
   DESTINATION lib/${PROJECT_NAME}
 )
 
-ament_export_targets(export_${PROJECT_NAME} export_${PROJECT_NAME})
 ament_python_install_package(${PROJECT_NAME})
 ament_export_definitions("${TF_UTIL_DEFINITIONS}")
 ament_export_dependencies(

--- a/swri_transform_util/include/swri_transform_util/transform.h
+++ b/swri_transform_util/include/swri_transform_util/transform.h
@@ -37,10 +37,10 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Transform.h>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/include/swri_transform_util/transform_manager.h
+++ b/swri_transform_util/include/swri_transform_util/transform_manager.h
@@ -40,7 +40,7 @@
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/swri_transform_util/include/swri_transform_util/transform_util.h
+++ b/swri_transform_util/include/swri_transform_util/transform_util.h
@@ -33,11 +33,11 @@
 #include <string>
 #include <array>
 
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Transform.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/include/swri_transform_util/transformer.h
+++ b/swri_transform_util/include/swri_transform_util/transformer.h
@@ -38,7 +38,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/swri_transform_util/include/swri_transform_util/utm_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/utm_transformer.h
@@ -36,7 +36,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <swri_transform_util/utm_util.h>

--- a/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
+++ b/swri_transform_util/include/swri_transform_util/wgs84_transformer.h
@@ -34,7 +34,7 @@
 #include <string>
 #include <vector>
 
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 

--- a/swri_transform_util/src/georeference.cpp
+++ b/swri_transform_util/src/georeference.cpp
@@ -108,10 +108,10 @@ namespace swri_transform_util
       // If we have an absolute path, we don't need to change it
       // Otherwise, we want to create a relative path from the .geo file
       // location
-      if (imagePath.is_absolute() == false)
+      if (imagePath.is_complete() == false)
       {
         boost::filesystem::path geoPath(path_);
-        image_path_ = (geoPath.parent_path() / imagePath.relative_path()).lexically_normal().string();
+        image_path_ = (geoPath.parent_path() / imagePath.relative_path()).normalize().string();
 
         RCLCPP_INFO(logger_, "georeference: Image path is %s", image_path_.c_str());
       }

--- a/swri_transform_util/src/local_xy_util.cpp
+++ b/swri_transform_util/src/local_xy_util.cpp
@@ -31,7 +31,7 @@
 #include <cmath>
 #include <functional>
 
-#include <tf2/utils.hpp>
+#include <tf2/utils.h>
 #include <rcutils/logging_macros.h>
 
 #include <swri_math_util/constants.h>

--- a/swri_transform_util/src/nodes/dynamic_transform_publisher.cpp
+++ b/swri_transform_util/src/nodes/dynamic_transform_publisher.cpp
@@ -1,6 +1,6 @@
 // *****************************************************************************
 //
-// Copyright (c) 2017-2025, Southwest Research Institute® (SwRI®)
+// Copyright (c) 2017, Southwest Research Institute® (SwRI®)
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -37,10 +37,10 @@
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/transform_broadcaster.h>
-#include <tf2/transform_datatypes.hpp>
-#include <tf2/LinearMath/Transform.hpp>
-#include <tf2/LinearMath/Vector3.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
 
 namespace swri_transform_util
 {

--- a/swri_transform_util/src/nodes/gps_transform_publisher.cpp
+++ b/swri_transform_util/src/nodes/gps_transform_publisher.cpp
@@ -37,7 +37,7 @@
 #include <swri_math_util/trig_util.h>
 #include <swri_transform_util/frames.h>
 #include <swri_transform_util/transform_manager.h>
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_broadcaster.h>
 
 namespace swri_transform_util

--- a/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
+++ b/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
@@ -32,7 +32,7 @@
 #include <geographic_msgs/msg/geo_pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <gps_msgs/msg/gps_fix.hpp>
-#include <tf2/utils.hpp>
+#include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>

--- a/swri_transform_util/test/test_transform_manager.cpp
+++ b/swri_transform_util/test/test_transform_manager.cpp
@@ -34,7 +34,7 @@
 #include <thread>
 
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/transform_datatypes.hpp>
+#include <tf2/transform_datatypes.h>
 
 #include <swri_transform_util/transform_manager.h>
 #include <swri_transform_util/frames.h>


### PR DESCRIPTION
There's a lot of issues with the changes to ament and library/target exporting, so this is a temporary revision to 3.7.4 to fix downstream build issues.