### PR TITLE
Add dependency on libopencv-dev for pkgs directly using OpenCV

### DIFF
--- a/swri_geometry_util/package.xml
+++ b/swri_geometry_util/package.xml
@@ -20,6 +20,7 @@
   -->
   <depend>eigen</depend>
   <depend>geos</depend>
+  <depend>libopencv-dev</depend>
   <depend>tf2</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/swri_image_util/package.xml
+++ b/swri_image_util/package.xml
@@ -20,6 +20,7 @@
   <depend>eigen</depend>
   <depend>image_geometry</depend>
   <depend>image_transport</depend>
+  <depend>libopencv-dev</depend>
   <depend>message_filters</depend>
   <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>

--- a/swri_opencv_util/package.xml
+++ b/swri_opencv_util/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   
   <depend>cv_bridge</depend>
+  <depend>libopencv-dev</depend>
   <depend>swri_math_util</depend>
 
   <export>

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -26,6 +26,7 @@
   <depend>geographiclib</depend>
   <depend>gps_msgs</depend>
   <depend>geos</depend>
+  <depend>libopencv-dev</depend>
   <depend>marti_nav_msgs</depend>
   <depend>proj</depend>
   <depend>rcl_interfaces</depend>


### PR DESCRIPTION
Fixes #780

These packages all use OpenCV directly (`find_package(OpenCV REQUIRED ...)`) but don't declare a dependency on it.

I haven't actually validated that this fixes the buildfarm issue, but I believe it should.