### PR TITLE
switch to using yaml_cpp_vendor

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(swri_roscpp REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 # tf2_geometry_msgs 0.12.1 broke API compatibility, so check which version
@@ -76,7 +77,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   opencv_imgproc
   opencv_video
   ${PROJ_LIBRARIES}
-  yaml-cpp
+  yaml-cpp::yaml-cpp
   ${geometry_msgs_TARGETS}
   rclcpp::rclcpp
   swri_math_util::swri_math_util

--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
-find_package(yaml-cpp REQUIRED)
 
 # tf2_geometry_msgs 0.12.1 broke API compatibility, so check which version
 # we need to use
@@ -77,13 +76,13 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   opencv_imgproc
   opencv_video
   ${PROJ_LIBRARIES}
-  yaml-cpp::yaml-cpp
   ${geometry_msgs_TARGETS}
   rclcpp::rclcpp
   swri_math_util::swri_math_util
   tf2::tf2
   tf2_geometry_msgs::tf2_geometry_msgs
-  tf2_ros::tf2_ros)
+  tf2_ros::tf2_ros
+  yaml-cpp)
 
 add_library(${PROJECT_NAME}_nodes SHARED
   src/nodes/dynamic_transform_publisher.cpp
@@ -97,7 +96,7 @@ target_include_directories(${PROJECT_NAME}_nodes PUBLIC
 target_include_directories(${PROJECT_NAME}_nodes
   SYSTEM
   INTERFACE
-  ${PROJ_INCLUDE_DIRS})
+    ${PROJ_INCLUDE_DIRS})
 
 target_compile_definitions(${PROJECT_NAME}
   PUBLIC "${TF_UTIL_DEFINITIONS}")
@@ -220,8 +219,7 @@ install(TARGETS
 
 ### Install Python Nodes/Scripts ###
 install(PROGRAMS nodes/initialize_origin.py
-  DESTINATION lib/${PROJECT_NAME}
-)
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_python_install_package(${PROJECT_NAME})
@@ -235,6 +233,6 @@ ament_export_dependencies(
   tf2
   tf2_geometry_msgs
   tf2_ros
-  yaml-cpp)
+  yaml_cpp_vendor)
 ament_package(CONFIG_EXTRAS cmake/swri_transform_util-extras.cmake)
 

--- a/swri_transform_util/package.xml
+++ b/swri_transform_util/package.xml
@@ -39,7 +39,7 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-yaml</exec_depend>


### PR DESCRIPTION
This change switches swri_transform_util to use yaml_cpp_vendor so that it will use the same version of yaml-cpp as is used by the core ros packages (e.g. [camera_calibration_parsers](https://github.com/ros-perception/image_common/blob/rolling/camera_calibration_parsers/CMakeLists.txt#L19-L20), [rviz](https://github.com/ros2/rviz/blob/rolling/rviz_common/CMakeLists.txt#L56), etc.) This is important for folks who are building from source on platforms that may have a different system version than the version ros wants.
We are on Ubuntu 22.04 which comes with yaml-cpp 0.7 and using ros2 jazzy which wants 0.8. Mixing versions can cause problems downstream.