### PR TITLE
ros::spin Exception Handling

### DIFF
--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -144,4 +144,10 @@ class OriginInitializer(rclpy.node.Node):
 if __name__ == "__main__":
     rclpy.init(args=sys.argv)
     node = OriginInitializer()
-    rclpy.spin(node)
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()


### PR DESCRIPTION
Adding exception handling around the node spinning so that it can gracefully shutdown without spamming the terminal.