### PR TITLE
Fixing multiple issues with how origin was subscribed to and interpreted

### DIFF
--- a/swri_transform_util/CMakeLists.txt
+++ b/swri_transform_util/CMakeLists.txt
@@ -209,6 +209,8 @@ if(BUILD_TESTING)
 
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/transform_manager.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/launch/local_xy_util.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/lat_lon_tf_echo.test.py)
+  add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/lat_lon_tf_echo_unsupported_origin.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_invalid_gps.test.py)
   add_launch_test(${CMAKE_CURRENT_SOURCE_DIR}/test/initialize_invalid_navsat.test.py)
   # The "custom" functionality appears to be gone in ROS 2.

--- a/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
+++ b/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
@@ -27,6 +27,10 @@
 //
 // *****************************************************************************
 
+#include <cmath>
+#include <set>
+#include <string>
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <geographic_msgs/msg/geo_pose.hpp>
@@ -60,11 +64,13 @@
  * <b>Subscribed Topics</b>
  * - \e /tf [geometry_msgs::Transform] - The transform from fixed_frame_id to
  *        target_frame_id must be published
- * - \e /local_xy_origin [geometry_msgs::PoseStamped] - This topic is used to 
- *        initialize the WGS84 transformer. Once it is initialized, the subscriber
- *        disconnects.
- *        The fields of this message should be filled as follows:
- *        - pose.position.y - longitude in degrees east of the prime meridian
+ * - \e /local_xy_origin [gps_msgs::GPSFix, geographic_msgs::GeoPose, or
+ *        geometry_msgs::PoseStamped] - This topic is used to initialize the
+ *        WGS84 transformer. The node subscribes with whichever of these types
+ *        the first publisher it discovers uses, and disconnects once it is
+ *        initialized.
+ *        The fields of a PoseStamped should be filled as follows:
+ *        - pose.position.x - longitude in degrees east of the prime meridian
  *        - pose.position.y - lattitude in degrees north of the equator.
  *        - pose.position.z - altitude in meters above the WGS84 ellipsoid
  *        All other fields in the message are ignored.
@@ -82,67 +88,118 @@ public:
       frame_id_(frame_id),
       fixed_frame_(fixed_frame)
   {
-    auto gps_callback = [this](const gps_msgs::msg::GPSFix::UniquePtr msg) -> void
-    {
-      xy_wgs84_util_.reset(
-          new swri_transform_util::LocalXyWgs84Util(
-              msg->latitude,
-              msg->longitude,
-              msg->track,
-              msg->altitude));
-      Unsubscribe();
-    };
-    gps_sub_ = this->create_subscription<gps_msgs::msg::GPSFix>(
-        "/local_xy_origin",
-        1,
-        gps_callback);
-
-    auto geopose_callback = [this](const geographic_msgs::msg::GeoPose::UniquePtr msg) -> void
-    {
-      xy_wgs84_util_.reset(
-          new swri_transform_util::LocalXyWgs84Util(
-              msg->position.latitude,
-              msg->position.longitude,
-              // The constructor takes degrees; getYaw() returns radians.
-              tf2::getYaw(msg->orientation) * swri_math_util::_rad_2_deg,
-              msg->position.altitude));
-      Unsubscribe();
-    };
-    geopose_sub_ = this->create_subscription<geographic_msgs::msg::GeoPose>(
-        "/local_xy_origin",
-        1,
-        geopose_callback);
-
-    auto posestamped_callback = [this](const geometry_msgs::msg::PoseStamped::UniquePtr msg) -> void
-    {
-      xy_wgs84_util_.reset(
-          new swri_transform_util::LocalXyWgs84Util(
-              msg->pose.position.y,    // Latitude
-              msg->pose.position.x,    // Longitude
-              0.0,                        // Heading
-              msg->pose.position.z));  // Altitude
-      Unsubscribe();
-    };
-    posestamped_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
-        "/local_xy_origin",
-        1,
-        posestamped_callback
-    );
+    // /local_xy_origin may carry any of several message types, but DDS allows
+    // only one type per topic within a process, so wait for a publisher to
+    // show which type it uses before subscribing.
+    origin_discovery_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(250),
+        std::bind(&LatLonTFEchoNode::SubscribeToOrigin, this));
 
     timer_ = this->create_wall_timer(std::chrono::seconds(1),
                                      std::bind(&LatLonTFEchoNode::TimerCallback, this));
   }
 
 private:
+  static constexpr const char* kOriginTopic = "/local_xy_origin";
+
   tf2_ros::Buffer buffer_;
   tf2_ros::TransformListener tf_listener_;
   rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr origin_discovery_timer_;
+  std::set<std::string> unsupported_origin_types_;  // Already warned about.
   std::shared_ptr<swri_transform_util::LocalXyWgs84Util> xy_wgs84_util_;
   rclcpp::Subscription<gps_msgs::msg::GPSFix>::SharedPtr gps_sub_;
   rclcpp::Subscription<geographic_msgs::msg::GeoPose>::SharedPtr geopose_sub_;
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr posestamped_sub_;
   std::string frame_id_;
   std::string fixed_frame_;
+
+  void SubscribeToOrigin()
+  {
+    for (const auto& info : this->get_publishers_info_by_topic(kOriginTopic))
+    {
+      // Match the publisher's reliability and durability so that the
+      // subscription is compatible with it, and so that a latched origin
+      // published before this node started is still delivered.
+      const rmw_qos_profile_t& publisher_qos = info.qos_profile().get_rmw_qos_profile();
+      rclcpp::QoS qos(1);
+      qos.reliability(publisher_qos.reliability);
+      qos.durability(publisher_qos.durability);
+
+      const std::string& type = info.topic_type();
+      if (type == "gps_msgs/msg/GPSFix")
+      {
+        gps_sub_ = this->create_subscription<gps_msgs::msg::GPSFix>(
+            kOriginTopic, qos,
+            std::bind(&LatLonTFEchoNode::HandleGpsFix, this, std::placeholders::_1));
+      }
+      else if (type == "geographic_msgs/msg/GeoPose")
+      {
+        geopose_sub_ = this->create_subscription<geographic_msgs::msg::GeoPose>(
+            kOriginTopic, qos,
+            std::bind(&LatLonTFEchoNode::HandleGeoPose, this, std::placeholders::_1));
+      }
+      else if (type == "geometry_msgs/msg/PoseStamped")
+      {
+        posestamped_sub_ = this->create_subscription<geometry_msgs::msg::PoseStamped>(
+            kOriginTopic, qos,
+            std::bind(&LatLonTFEchoNode::HandlePoseStamped, this, std::placeholders::_1));
+      }
+      else
+      {
+        // Keep polling in case a supported publisher appears, but say why the
+        // node is still waiting. Once per type, since this runs every poll.
+        if (unsupported_origin_types_.insert(type).second)
+        {
+          RCLCPP_WARN(this->get_logger(),
+              "%s is published as %s; expected gps_msgs/msg/GPSFix, "
+              "geographic_msgs/msg/GeoPose or geometry_msgs/msg/PoseStamped",
+              kOriginTopic, type.c_str());
+        }
+        continue;
+      }
+
+      RCLCPP_INFO(this->get_logger(), "Subscribing to %s as %s", kOriginTopic, type.c_str());
+      origin_discovery_timer_->cancel();
+      return;
+    }
+  }
+
+  void HandleGpsFix(const gps_msgs::msg::GPSFix::UniquePtr msg)
+  {
+    xy_wgs84_util_.reset(
+        new swri_transform_util::LocalXyWgs84Util(
+            msg->latitude,
+            msg->longitude,
+            // The constructor takes degrees ENU (counter-clockwise from
+            // east); track is a compass heading (clockwise from north).
+            90.0 - msg->track,
+            msg->altitude));
+    Unsubscribe();
+  }
+
+  void HandleGeoPose(const geographic_msgs::msg::GeoPose::UniquePtr msg)
+  {
+    xy_wgs84_util_.reset(
+        new swri_transform_util::LocalXyWgs84Util(
+            msg->position.latitude,
+            msg->position.longitude,
+            // The constructor takes degrees; getYaw() returns radians.
+            tf2::getYaw(msg->orientation) * swri_math_util::_rad_2_deg,
+            msg->position.altitude));
+    Unsubscribe();
+  }
+
+  void HandlePoseStamped(const geometry_msgs::msg::PoseStamped::UniquePtr msg)
+  {
+    xy_wgs84_util_.reset(
+        new swri_transform_util::LocalXyWgs84Util(
+            msg->pose.position.y,    // Latitude
+            msg->pose.position.x,    // Longitude
+            0.0,                        // Heading
+            msg->pose.position.z));  // Altitude
+    Unsubscribe();
+  }
 
   void Unsubscribe()
   {
@@ -178,12 +235,12 @@ private:
     xy_wgs84_util_->ToWgs84(
         transform.getOrigin().x(), transform.getOrigin().y(),
         lat, lon);
-    tf2::Quaternion q = transform.getRotation();
-    q.setY(0);
-    q.setX(0);
-    q.normalize();
-    double heading = -q.getAngle() * swri_math_util::_rad_2_deg + 90;
-    while (heading < 0)
+    // The yaw is counter-clockwise from the fixed frame's X axis, which lies
+    // ReferenceAngle() degrees counter-clockwise from east, while a compass
+    // heading is clockwise from north.
+    double yaw = tf2::getYaw(transform.getRotation()) * swri_math_util::_rad_2_deg;
+    double heading = std::fmod(90.0 - (yaw + xy_wgs84_util_->ReferenceAngle()), 360.0);
+    if (heading < 0)
     {
       heading += 360;
     }

--- a/swri_transform_util/test/lat_lon_tf_echo.test.py
+++ b/swri_transform_util/test/lat_lon_tf_echo.test.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# *****************************************************************************
+#
+# Copyright (c) 2026, Southwest Research Institute® (SwRI®)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# *****************************************************************************
+
+import math
+import os
+import re
+import time
+import unittest
+
+import pytest
+
+import ament_index_python
+import launch
+import launch_testing
+import rclpy
+from gps_msgs.msg import GPSFix
+from launch_ros.actions import Node
+
+ORIGIN_LAT = 29.45
+ORIGIN_LON = -98.61
+# Compass heading, clockwise from north. 30 degrees keeps the correct
+# conversion (90 - track), passing track through unconverted, and 90 + track
+# all distinguishable, which 0 and 45 do not.
+TRACK = 30.0
+# How far along the local X axis the target frame sits.
+DISTANCE = 100.0
+# The target frame's yaw in the local frame, counter-clockwise, in degrees.
+# It is negative so that dropping its sign is caught, and nonzero so that
+# ignoring the reference angle is too: those mistakes print 10 and 110 degrees
+# where the correct heading is 50.
+TARGET_YAW = -20.0
+
+OUTPUT_RE = re.compile(
+    r'Latitude: (-?\d+\.\d+)°, Longitude: (-?\d+\.\d+)°, Heading: (-?\d+\.\d+)°')
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    # lat_lon_tf_echo is installed to bin/ rather than lib/<package>, so it is
+    # launched by path instead of as a launch_ros Node.
+    echo = launch.actions.ExecuteProcess(
+        cmd=[
+            os.path.join(
+                ament_index_python.get_package_prefix('swri_transform_util'),
+                'bin', 'lat_lon_tf_echo'),
+            'far_field',
+            'base_link',
+        ],
+        name='lat_lon_tf_echo',
+        # The node reports with printf, which a pipe would buffer indefinitely.
+        emulate_tty=True,
+        output='screen',
+    )
+
+    target_tf = Node(
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--x', str(DISTANCE),
+            '--yaw', str(math.radians(TARGET_YAW)),
+            '--frame-id', 'far_field',
+            '--child-frame-id', 'base_link',
+        ],
+    )
+
+    return launch.LaunchDescription([
+        echo,
+        target_tf,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'echo': echo}
+
+
+class LatLonTfEchoGpsFixTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('lat_lon_tf_echo_test')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def reported_position(self, proc_output, echo):
+        """Publish a GPSFix origin until the node reports, and return the report."""
+        publisher = self.node.create_publisher(GPSFix, '/local_xy_origin', 1)
+        fix = GPSFix()
+        fix.latitude = ORIGIN_LAT
+        fix.longitude = ORIGIN_LON
+        fix.altitude = 0.0
+        fix.track = TRACK
+
+        # The node only subscribes once it has discovered a publisher, so keep
+        # publishing until it reports a position.
+        deadline = time.monotonic() + 30.0
+        reported = False
+        while not reported and time.monotonic() < deadline:
+            publisher.publish(fix)
+            # waitFor() searches stderr unless told otherwise, and the node
+            # reports on stdout.
+            reported = proc_output.waitFor(
+                OUTPUT_RE, process=echo, timeout=0.5, stream='stdout')
+        self.assertTrue(reported, 'lat_lon_tf_echo never reported a position')
+
+        text = ''.join(output.text.decode()
+                       for output in proc_output[echo] if output.from_stdout)
+        match = OUTPUT_RE.search(text)
+        self.assertIsNotNone(match, text)
+        return tuple(float(group) for group in match.groups())
+
+    def test_position_follows_gps_track(self, proc_output, echo):
+        lat, lon, _ = self.reported_position(proc_output, echo)
+
+        # Metres per degree at the origin's latitude, which is ample precision
+        # for the 100 m offset and six decimal places the node prints.
+        phi = math.radians(ORIGIN_LAT)
+        metres_per_deg_lat = (111132.92 - 559.82 * math.cos(2 * phi)
+                              + 1.175 * math.cos(4 * phi))
+        metres_per_deg_lon = (111412.84 * math.cos(phi)
+                              - 93.5 * math.cos(3 * phi))
+        north = (lat - ORIGIN_LAT) * metres_per_deg_lat
+        east = (lon - ORIGIN_LON) * metres_per_deg_lon
+
+        # The local X axis points along the GPS track, so the target lies
+        # DISTANCE metres away on a compass bearing of TRACK.
+        self.assertAlmostEqual(DISTANCE, math.hypot(north, east), delta=0.5)
+        self.assertAlmostEqual(
+            TRACK, math.degrees(math.atan2(east, north)), delta=0.5)
+
+    def test_heading_is_compass_bearing(self, proc_output, echo):
+        _, _, heading = self.reported_position(proc_output, echo)
+
+        # The local X axis points along the GPS track, and a counter-clockwise
+        # yaw from it turns the heading anticlockwise on the compass.
+        self.assertAlmostEqual((TRACK - TARGET_YAW) % 360.0, heading, delta=0.01)

--- a/swri_transform_util/test/lat_lon_tf_echo_unsupported_origin.test.py
+++ b/swri_transform_util/test/lat_lon_tf_echo_unsupported_origin.test.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# *****************************************************************************
+#
+# Copyright (c) 2026, Southwest Research Institute® (SwRI®)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * Neither the name of Southwest Research Institute® (SwRI®) nor the
+#       names of its contributors may be used to endorse or promote products
+#       derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# *****************************************************************************
+
+import os
+import time
+import unittest
+
+import pytest
+
+import ament_index_python
+import launch
+import launch_testing
+import rclpy
+from gps_msgs.msg import GPSFix
+from launch_ros.actions import Node
+
+WARNING = '/local_xy_origin is published as sensor_msgs/msg/NavSatFix'
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    # lat_lon_tf_echo is installed to bin/ rather than lib/<package>, so it is
+    # launched by path instead of as a launch_ros Node.
+    echo = launch.actions.ExecuteProcess(
+        cmd=[
+            os.path.join(
+                ament_index_python.get_package_prefix('swri_transform_util'),
+                'bin', 'lat_lon_tf_echo'),
+            'far_field',
+            'base_link',
+        ],
+        name='lat_lon_tf_echo',
+        # The node reports with printf, which a pipe would buffer indefinitely.
+        emulate_tty=True,
+        output='screen',
+    )
+
+    target_tf = Node(
+        package='tf2_ros',
+        executable='static_transform_publisher',
+        arguments=[
+            '--x', '100',
+            '--frame-id', 'far_field',
+            '--child-frame-id', 'base_link',
+        ],
+    )
+
+    # Published from its own process, since DDS allows only one type per topic
+    # within a process and the test itself publishes a GPSFix later.
+    unsupported_origin = launch.actions.ExecuteProcess(
+        cmd=['ros2', 'topic', 'pub', '-r', '2',
+             '/local_xy_origin', 'sensor_msgs/msg/NavSatFix', '{}'],
+        name='unsupported_origin',
+        output='screen',
+    )
+
+    return launch.LaunchDescription([
+        echo,
+        target_tf,
+        unsupported_origin,
+        launch_testing.actions.ReadyToTest(),
+    ]), {'echo': echo}
+
+
+class LatLonTfEchoUnsupportedOriginTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('lat_lon_tf_echo_unsupported_origin_test')
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_warns_once_then_accepts_supported_origin(self, proc_output, echo):
+        self.assertTrue(
+            proc_output.waitFor(WARNING, process=echo, timeout=30, stream='stderr'),
+            'lat_lon_tf_echo never warned about the unsupported origin type')
+
+        # Discovery polls every 250 ms, so this gives it several chances to
+        # repeat the warning.
+        time.sleep(2.0)
+        stderr = ''.join(output.text.decode()
+                         for output in proc_output[echo] if output.from_stderr)
+        self.assertEqual(1, stderr.count(WARNING), stderr)
+
+        # Polling continues after the warning, so a supported origin that shows
+        # up later is still used.
+        publisher = self.node.create_publisher(GPSFix, '/local_xy_origin', 1)
+        fix = GPSFix()
+        fix.latitude = 29.45
+        fix.longitude = -98.61
+
+        deadline = time.monotonic() + 30.0
+        reported = False
+        while not reported and time.monotonic() < deadline:
+            publisher.publish(fix)
+            reported = proc_output.waitFor(
+                'Latitude:', process=echo, timeout=0.5, stream='stdout')
+        self.assertTrue(reported, 'lat_lon_tf_echo never reported a position')


### PR DESCRIPTION
- lat_lon_tf_echo: fix an abort at startup under Fast DDS caused by
  subscribing to /local_xy_origin with three message types at once.
  The node now waits for a publisher and subscribes with its type,
  matching its reliability and durability so latched origins arrive.
- lat_lon_tf_echo: warn once per type when /local_xy_origin is
  published with an unsupported message type, instead of waiting
  silently.
- lat_lon_tf_echo: convert GPSFix track (compass heading) to the ENU
  angle the LocalXyWgs84Util constructor expects (90 - track), and
  GeoPose yaw from radians to degrees.
- lat_lon_tf_echo: fix the printed heading, which ignored the
  reference angle and dropped the sign of the target's yaw.
- lat_lon_tf_echo: correct the subscribed-topic documentation.