### PR TITLE
Add heading support to origin initialization

### DIFF
--- a/swri_transform_util/nodes/initialize_origin.py
+++ b/swri_transform_util/nodes/initialize_origin.py
@@ -68,6 +68,16 @@ class OriginInitializer(rclpy.node.Node):
                                                                 name='local_xy_navsatfix_topic',
                                                                 type=rclpy.parameter.ParameterType.PARAMETER_STRING
                                                             ))
+        self.use_gpsfix_track_param = self.declare_parameter('local_xy_use_gpsfix_track',
+                                                             False,
+                                                             descriptor=rclpy.node.ParameterDescriptor(
+                                                                 name='local_xy_use_gpsfix_track',
+                                                                 type=rclpy.parameter.ParameterType.PARAMETER_BOOL,
+                                                                 description='Point the local X axis along the '
+                                                                             'GPSFix track when the track is finite '
+                                                                             'and its uncertainty is finite and '
+                                                                             'positive, rather than east'
+                                                             ))
         self.local_xy_origins_param = self.declare_parameter('local_xy_origins',
                                                              [nan, nan, nan, nan],
                                                              descriptor=rclpy.node.ParameterDescriptor(
@@ -77,6 +87,7 @@ class OriginInitializer(rclpy.node.Node):
 
         self.get_logger().info("Origin: %s" % self.local_xy_origin_param.value)
         self.get_logger().info("Frame: %s" % self.local_xy_frame_param.value)
+        self.get_logger().info("Use GPSFix track: %s" % self.use_gpsfix_track_param.value)
 
         self.manager = OriginManager(self, self.local_xy_frame_param.value)
         if self.local_xy_origin_param.value == 'auto':
@@ -93,9 +104,11 @@ class OriginInitializer(rclpy.node.Node):
             self.subscribers = [gps_sub, navsat_sub]
         elif type(self.local_xy_origins_param.value) == list:
             if (len(self.local_xy_origins_param.value) != 4):
-               self.get_logger().fatal(f'{self.local_xy_origins_param.name} should have len 4 [lat, lon, alt, heading]')
+               self.get_logger().fatal(f'{self.local_xy_origins_param.name} should have len 4 [lat, lon, alt, heading], '
+                                       'with heading in degrees ENU')
                exit(1)
-            self.manager.set_origin("manual", *self.local_xy_origins_param.value[0:3])
+            latitude, longitude, altitude, heading = self.local_xy_origins_param.value
+            self.manager.set_origin("manual", latitude, longitude, altitude, heading=heading)
         elif type(self.local_xy_origins_param.value) == str:
             try:
                 origins_list = yaml.safe_load(self.local_xy_origins_param.value)
@@ -131,7 +144,7 @@ class OriginInitializer(rclpy.node.Node):
     def gps_callback(self, msg):
         try:
             self.get_logger().info('Got GPSFix message.')
-            self.manager.set_origin_from_gps(msg)
+            self.manager.set_origin_from_gps(msg, use_track=self.use_gpsfix_track_param.value)
             self.get_logger().info('Successfully set origin; unsubscribing.')
             while self.subscribers:
                 sub = self.subscribers.pop()

--- a/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
+++ b/swri_transform_util/src/nodes/lat_lon_tf_echo.cpp
@@ -73,6 +73,8 @@
  *        - pose.position.x - longitude in degrees east of the prime meridian
  *        - pose.position.y - lattitude in degrees north of the equator.
  *        - pose.position.z - altitude in meters above the WGS84 ellipsoid
+ *        - pose.orientation - its yaw is the direction of the local X axis,
+ *          counter-clockwise from east
  *        All other fields in the message are ignored.
  */
 
@@ -196,7 +198,9 @@ private:
         new swri_transform_util::LocalXyWgs84Util(
             msg->pose.position.y,    // Latitude
             msg->pose.position.x,    // Longitude
-            0.0,                        // Heading
+            // The orientation's yaw is the heading in radians ENU; the
+            // constructor takes degrees.
+            tf2::getYaw(msg->pose.orientation) * swri_math_util::_rad_2_deg,
             msg->pose.position.z));  // Altitude
     Unsubscribe();
   }

--- a/swri_transform_util/swri_transform_util/origin_manager.py
+++ b/swri_transform_util/swri_transform_util/origin_manager.py
@@ -32,6 +32,7 @@
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 from geometry_msgs.msg import PoseStamped, TransformStamped
 from gps_msgs.msg import GPSStatus
+import math
 import rclpy.node
 import rclpy.qos
 from sensor_msgs.msg import NavSatStatus
@@ -122,6 +123,7 @@ class OriginManager(object):
         self.timer = None
         self.origin = None
         self.origin_source = None
+        self.origin_heading = None
         self.local_xy_frame = local_xy_frame
         if local_xy_frame_identity is None:
             local_xy_frame_identity = local_xy_frame + "__identity"
@@ -132,7 +134,7 @@ class OriginManager(object):
         self.diagnostic_pub = node.create_publisher(DiagnosticArray, '/diagnostics', 2)
         self.tf_broadcaster = TransformBroadcaster(self.node)
 
-    def set_origin(self, source, latitude, longitude, altitude, stamp=None):
+    def set_origin(self, source, latitude, longitude, altitude, stamp=None, heading=0.0):
         """
         Set the origin to the position described by the arguments and publish it.
 
@@ -147,6 +149,9 @@ class OriginManager(object):
             stamp (rospy.Time): The time to use for the origin's header.stamp field.
                 If the argument is `None`, the stamp is not set and defaults to
                 `rospy.Time(0)`. (default None).
+            heading (float): The direction of the local X axis in degrees ENU, i.e.
+                counter-clockwise from east. It is published as the yaw of the
+                origin's orientation. (default 0.0).
         """
         if self.origin is not None:
             return
@@ -157,15 +162,17 @@ class OriginManager(object):
         origin.pose.position.y = latitude
         origin.pose.position.x = longitude
         origin.pose.position.z = altitude
-        # Heading is always 0
+        # The heading is a rotation about the vertical axis only.
+        yaw = math.radians(heading)
         origin.pose.orientation.x = 0.0
         origin.pose.orientation.y = 0.0
-        origin.pose.orientation.z = 0.0
-        origin.pose.orientation.w = 1.0
+        origin.pose.orientation.z = math.sin(yaw / 2.0)
+        origin.pose.orientation.w = math.cos(yaw / 2.0)
         self.origin_source = source
+        self.origin_heading = heading
         self.origin = origin
-        self.node.get_logger().info("Origin from '{}' source set to {}, {}, {}".format(
-            source, latitude, longitude, altitude))
+        self.node.get_logger().info("Origin from '{}' source set to {}, {}, {}, heading {}".format(
+            source, latitude, longitude, altitude, heading))
         self._publish_origin()
 
     def _publish_origin(self):
@@ -178,14 +185,16 @@ class OriginManager(object):
 
         Args:
             origin_dict (dict): A dictionary containing the keys "latitude", "longitude", and
-                "altitude" with appropriate float values
+                "altitude" with appropriate float values, and optionally "heading" in degrees
+                ENU (default 0.0)
 
         Raises:
             KeyError: If `origin_dict` does not contain all of the required keys.
         """
         self.set_origin("manual", origin_dict["latitude"],
                         origin_dict["longitude"],
-                        origin_dict["altitude"])
+                        origin_dict["altitude"],
+                        heading=origin_dict.get("heading", 0.0))
 
     def set_origin_from_list(self, origin_name, origin_list):
         """
@@ -209,12 +218,15 @@ class OriginManager(object):
                 origin_name, origins_list_str)
             raise KeyError(message)
 
-    def set_origin_from_gps(self, msg):
+    def set_origin_from_gps(self, msg, use_track=False):
         """
         Set the local origin from a gps_common.msg.GPSFix object.
 
         Args:
             msg (gps_common.msg.GPSFix): A GPSFix message with the local origin
+            use_track (bool): If True, point the local X axis along the GPS track, provided
+                that the track is finite and its uncertainty is finite and positive;
+                otherwise the heading is 0, pointing the X axis east. (default False).
 
         Raises:
             InvalidFixException: If `msg.status.status` is STATUS_NO_FIX
@@ -222,7 +234,22 @@ class OriginManager(object):
         if msg.status.status == GPSStatus.STATUS_NO_FIX:
             message = 'Cannot set origin from invalid GPSFix. Waiting for a valid one...'
             raise InvalidFixException(message)
-        self.set_origin("gpsfix", msg.latitude, msg.longitude, msg.altitude, msg.header.stamp)
+        heading = 0.0
+        if use_track:
+            # An uncertainty of 0 is what a driver that never fills it in leaves,
+            # so it is not taken as a sign that the track is trustworthy.
+            if (math.isfinite(msg.track) and math.isfinite(msg.err_track)
+                    and msg.err_track > 0.0):
+                # The track is a compass heading, clockwise from north, while the
+                # origin's heading is ENU, counter-clockwise from east.
+                heading = 90.0 - msg.track
+            else:
+                self.node.get_logger().warning(
+                    'GPSFix track {} with uncertainty {} is not usable, since the track must '
+                    'be finite and its uncertainty finite and positive; using a heading of 0 '
+                    'for the origin'.format(msg.track, msg.err_track))
+        self.set_origin("gpsfix", msg.latitude, msg.longitude, msg.altitude, msg.header.stamp,
+                        heading)
 
     def set_origin_from_navsat(self, msg):
         """
@@ -284,6 +311,9 @@ class OriginManager(object):
 
             altitude = "%f" % self.origin.pose.position.z
             status.values.append(KeyValue(key="Altitude", value=altitude))
+
+            heading = "%f" % self.origin_heading
+            status.values.append(KeyValue(key="Heading", value=heading))
 
             diagnostic.status.append(status)
             self.diagnostic_pub.publish(diagnostic)

--- a/swri_transform_util/test/initialize_origin_auto_gps.test.py
+++ b/swri_transform_util/test/initialize_origin_auto_gps.test.py
@@ -40,6 +40,10 @@ NAME = 'test_initialize_origin'
 
 ORIGIN_TOPIC = '/local_xy_origin'
 
+# The compass track of the published GPSFix. Its ENU equivalent, 60 degrees,
+# differs from the default heading of 0 and from the track itself.
+TRACK = 30.0
+
 def get_tests(*, args=[]):
     test_path = os.path.join(
             ament_index_python.get_package_prefix("swri_transform_util"),
@@ -48,20 +52,33 @@ def get_tests(*, args=[]):
     )
 
     return launch.actions.ExecuteProcess(
-            cmd=["python3", test_path, "auto_gps"],
+            cmd=["python3", test_path, "auto_gps", *args],
             name="init_origin_auto_gps_test",
             additional_env={"PYTHONBUFFERED": "1"},
             output="screen",
     )
 
 @pytest.mark.launch_test
-def generate_test_description():
+@launch_testing.parametrize('use_track, err_track, expected_heading', [
+    # The track is ignored unless asked for.
+    (False, 2.0, 0.0),
+    (True, 2.0, 90.0 - TRACK),
+    # A track of unknown uncertainty falls back to the default heading.
+    (True, float('nan'), 0.0),
+    (True, float('inf'), 0.0),
+    # So does one whose uncertainty is not positive, which includes the 0 that
+    # a driver leaves when it never fills the uncertainty in.
+    (True, 0.0, 0.0),
+    (True, -1.0, 0.0),
+])
+def generate_test_description(use_track, err_track, expected_heading):
     init_origin = Node(
         package="swri_transform_util",
         name="origin",
         executable="initialize_origin.py",
         parameters=[{
             "local_xy_frame": "/far_field",
+            "local_xy_use_gpsfix_track": use_track,
         }]
     )
 
@@ -71,11 +88,13 @@ def generate_test_description():
                 launch_testing.util.KeepAliveProc(),
                 launch_testing.actions.ReadyToTest(),
             ]
-    )
+    # Not 'test_args', which launch_testing reserves for the launch arguments
+    # given on its command line.
+    ), {'script_args': [str(TRACK), str(err_track), str(expected_heading)]}
 
 class AutoGpsTest(unittest.TestCase):
-    def test_auto_gps(self, launch_service, proc_info, proc_output):
-        tests = get_tests();
+    def test_auto_gps(self, launch_service, proc_info, proc_output, script_args):
+        tests = get_tests(args=script_args);
         with launch_testing.tools.launch_process(
             launch_service, tests, proc_info, proc_output
         ):

--- a/swri_transform_util/test/initialize_origin_manual.test.py
+++ b/swri_transform_util/test/initialize_origin_manual.test.py
@@ -40,6 +40,9 @@ NAME = 'test_initialize_origin'
 
 ORIGIN_TOPIC = '/local_xy_origin'
 
+# Nonzero, so that dropping the heading is caught. Degrees ENU.
+HEADING = 30.0
+
 def get_tests(*, args=[]):
     test_path = os.path.join(
             ament_index_python.get_package_prefix("swri_transform_util"),
@@ -48,40 +51,35 @@ def get_tests(*, args=[]):
     )
 
     return launch.actions.ExecuteProcess(
-            cmd=["python3", test_path, "manual"],
+            cmd=["python3", test_path, "manual", *args],
             name="init_origin_auto_gps_test",
             additional_env={"PYTHONBUFFERED": "1"},
             output="screen",
     )
 
+# Each way of specifying the origin is launched on its own, since the test
+# accepts the first origin it receives.
 @pytest.mark.launch_test
-def generate_test_description():
-    init_origin_array = Node(
+@launch_testing.parametrize('local_xy_origins', [
+    [29.45196669, -98.61370577, 233.719, HEADING],
+    "[{name: 'swri', latitude: 29.45196669, longitude: -98.61370577, altitude: 233.719, "
+    f"heading: {HEADING}}}]",
+])
+def generate_test_description(local_xy_origins):
+    init_origin = Node(
         package="swri_transform_util",
         name="origin",
         executable="initialize_origin.py",
         parameters=[{
             "local_xy_frame": "/far_field",
             "local_xy_origin": "swri",
-            "local_xy_origins": [29.45196669, -98.61370577, 233.719, 0.0],
-        }]
-    )
-
-    init_origin_dicitonary = Node(
-        package="swri_transform_util",
-        name="origin",
-        executable="initialize_origin.py",
-        parameters=[{
-            "local_xy_frame": "/far_field",
-            "local_xy_origin": "swri",
-            "local_xy_origins": "[{name: 'swri', latitude: 29.45196669, longitude: -98.61370577, altitude: 233.719, heading: 0.0}]",
+            "local_xy_origins": local_xy_origins,
         }]
     )
 
     return launch.LaunchDescription(
             [
-                init_origin_array,
-                init_origin_dicitonary,
+                init_origin,
                 launch_testing.util.KeepAliveProc(),
                 launch_testing.actions.ReadyToTest(),
             ]
@@ -89,7 +87,7 @@ def generate_test_description():
 
 class ManualTest(unittest.TestCase):
     def test_manual(self, launch_service, proc_info, proc_output):
-        tests = get_tests();
+        tests = get_tests(args=[str(HEADING)]);
         with launch_testing.tools.launch_process(
             launch_service, tests, proc_info, proc_output
         ):

--- a/swri_transform_util/test/lat_lon_tf_echo.test.py
+++ b/swri_transform_util/test/lat_lon_tf_echo.test.py
@@ -40,14 +40,16 @@ import ament_index_python
 import launch
 import launch_testing
 import rclpy
+from geometry_msgs.msg import PoseStamped
 from gps_msgs.msg import GPSFix
 from launch_ros.actions import Node
 
 ORIGIN_LAT = 29.45
 ORIGIN_LON = -98.61
-# Compass heading, clockwise from north. 30 degrees keeps the correct
-# conversion (90 - track), passing track through unconverted, and 90 + track
-# all distinguishable, which 0 and 45 do not.
+# The compass bearing of the local X axis, clockwise from north. 30 degrees
+# keeps the correct conversion from a GPSFix track (90 - track), passing track
+# through unconverted, and 90 + track all distinguishable, which 0 and 45 do
+# not.
 TRACK = 30.0
 # How far along the local X axis the target frame sits.
 DISTANCE = 100.0
@@ -61,8 +63,32 @@ OUTPUT_RE = re.compile(
     r'Latitude: (-?\d+\.\d+)°, Longitude: (-?\d+\.\d+)°, Heading: (-?\d+\.\d+)°')
 
 
+def gps_fix_origin():
+    fix = GPSFix()
+    fix.latitude = ORIGIN_LAT
+    fix.longitude = ORIGIN_LON
+    fix.altitude = 0.0
+    fix.track = TRACK
+    return fix
+
+
+def pose_stamped_origin():
+    pose = PoseStamped()
+    pose.pose.position.y = ORIGIN_LAT
+    pose.pose.position.x = ORIGIN_LON
+    pose.pose.position.z = 0.0
+    # The yaw is ENU, counter-clockwise from east.
+    yaw = math.radians(90.0 - TRACK)
+    pose.pose.orientation.z = math.sin(yaw / 2.0)
+    pose.pose.orientation.w = math.cos(yaw / 2.0)
+    return pose
+
+
+# Both origins describe the same local frame, so the node's report must be the
+# same for each.
 @pytest.mark.launch_test
-def generate_test_description():
+@launch_testing.parametrize('origin', [gps_fix_origin(), pose_stamped_origin()])
+def generate_test_description(origin):
     # lat_lon_tf_echo is installed to bin/ rather than lib/<package>, so it is
     # launched by path instead of as a launch_ros Node.
     echo = launch.actions.ExecuteProcess(
@@ -94,10 +120,10 @@ def generate_test_description():
         echo,
         target_tf,
         launch_testing.actions.ReadyToTest(),
-    ]), {'echo': echo}
+    ]), {'echo': echo, 'origin': origin}
 
 
-class LatLonTfEchoGpsFixTest(unittest.TestCase):
+class LatLonTfEchoOriginTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -113,21 +139,16 @@ class LatLonTfEchoGpsFixTest(unittest.TestCase):
     def tearDown(self):
         self.node.destroy_node()
 
-    def reported_position(self, proc_output, echo):
-        """Publish a GPSFix origin until the node reports, and return the report."""
-        publisher = self.node.create_publisher(GPSFix, '/local_xy_origin', 1)
-        fix = GPSFix()
-        fix.latitude = ORIGIN_LAT
-        fix.longitude = ORIGIN_LON
-        fix.altitude = 0.0
-        fix.track = TRACK
+    def reported_position(self, proc_output, echo, origin):
+        """Publish the origin until the node reports, and return the report."""
+        publisher = self.node.create_publisher(type(origin), '/local_xy_origin', 1)
 
         # The node only subscribes once it has discovered a publisher, so keep
         # publishing until it reports a position.
         deadline = time.monotonic() + 30.0
         reported = False
         while not reported and time.monotonic() < deadline:
-            publisher.publish(fix)
+            publisher.publish(origin)
             # waitFor() searches stderr unless told otherwise, and the node
             # reports on stdout.
             reported = proc_output.waitFor(
@@ -140,8 +161,8 @@ class LatLonTfEchoGpsFixTest(unittest.TestCase):
         self.assertIsNotNone(match, text)
         return tuple(float(group) for group in match.groups())
 
-    def test_position_follows_gps_track(self, proc_output, echo):
-        lat, lon, _ = self.reported_position(proc_output, echo)
+    def test_position_follows_origin_heading(self, proc_output, echo, origin):
+        lat, lon, _ = self.reported_position(proc_output, echo, origin)
 
         # Metres per degree at the origin's latitude, which is ample precision
         # for the 100 m offset and six decimal places the node prints.
@@ -153,15 +174,16 @@ class LatLonTfEchoGpsFixTest(unittest.TestCase):
         north = (lat - ORIGIN_LAT) * metres_per_deg_lat
         east = (lon - ORIGIN_LON) * metres_per_deg_lon
 
-        # The local X axis points along the GPS track, so the target lies
-        # DISTANCE metres away on a compass bearing of TRACK.
+        # The local X axis points along a compass bearing of TRACK, so the
+        # target lies DISTANCE metres away in that direction.
         self.assertAlmostEqual(DISTANCE, math.hypot(north, east), delta=0.5)
         self.assertAlmostEqual(
             TRACK, math.degrees(math.atan2(east, north)), delta=0.5)
 
-    def test_heading_is_compass_bearing(self, proc_output, echo):
-        _, _, heading = self.reported_position(proc_output, echo)
+    def test_heading_is_compass_bearing(self, proc_output, echo, origin):
+        _, _, heading = self.reported_position(proc_output, echo, origin)
 
-        # The local X axis points along the GPS track, and a counter-clockwise
-        # yaw from it turns the heading anticlockwise on the compass.
+        # The local X axis points along a compass bearing of TRACK, and a
+        # counter-clockwise yaw from it turns the heading anticlockwise on the
+        # compass.
         self.assertAlmostEqual((TRACK - TARGET_YAW) % 360.0, heading, delta=0.01)

--- a/swri_transform_util/test/test_initialize_origin.py
+++ b/swri_transform_util/test/test_initialize_origin.py
@@ -55,9 +55,15 @@ swri = {
 }
 
 class TestInitializeOrigin(unittest.TestCase):
-    def __init__(self):
+    def __init__(self, expected_heading=0.0):
+        """
+        Args:
+            expected_heading (float): The heading the published origin should have, in
+                degrees ENU. (default 0.0).
+        """
         super().__init__()
         self.got_origin = False
+        self.expected_heading = expected_heading
 
     def _yaw_from_quaternion(self, w, x, y, z):
         sc = 2 * ((w * z) + (x * y))
@@ -97,7 +103,9 @@ class TestInitializeOrigin(unittest.TestCase):
                 msg.pose.orientation.x,
                 msg.pose.orientation.y,
                 msg.pose.orientation.z)
-            self.assertAlmostEqual(yaw, 0)
+            self.node.get_logger().info("Origin heading is %f; expected %f" % (
+                math.degrees(yaw), self.expected_heading))
+            self.assertAlmostEqual(yaw, math.radians(self.expected_heading))
         elif self.origin_class == GPSFix:
             self.node.get_logger().info("Status: %d" % msg.status.status)
             self.assertEqual(msg.status.status, GPSStatus.STATUS_FIX)
@@ -169,9 +177,18 @@ class TestInvalidOrigin(unittest.TestCase):
 
 
 class TestAutoOriginFromGPSFix(TestInitializeOrigin):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, track=swri['heading'], err_track=0.0, expected_heading=0.0):
+        """
+        Args:
+            track (float): The compass track of the published GPSFix in degrees.
+            err_track (float): The track uncertainty of the published GPSFix in degrees.
+            expected_heading (float): The heading the published origin should have, in
+                degrees ENU.
+        """
+        super().__init__(expected_heading)
         self.node = rclpy.create_node('test_auto_origin_from_gps_fix')
+        self.node.get_logger().info("Publishing a GPSFix with track %f, err_track %f" % (
+            track, err_track))
         gps_pub = self.node.create_publisher(
             GPSFix, 'gps',
             QoSProfile(
@@ -186,7 +203,8 @@ class TestAutoOriginFromGPSFix(TestInitializeOrigin):
         gps_msg.latitude = swri['latitude']
         gps_msg.longitude = swri['longitude']
         gps_msg.altitude = swri['altitude']
-        gps_msg.track = swri['heading']
+        gps_msg.track = track
+        gps_msg.err_track = err_track
         gps_msg.header.stamp = msg_stamp
         gps_pub.publish(gps_msg)
         while not self.got_origin:
@@ -296,8 +314,8 @@ class TestInvalidNavSatFix(TestInvalidOrigin):
 
 
 class TestManualOrigin(TestInitializeOrigin):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, expected_heading=0.0):
+        super().__init__(expected_heading)
         self.node = rclpy.create_node('test_manual_origin')
         origin_sub = self.subscribeToOrigin()
         while not self.got_origin:
@@ -309,8 +327,10 @@ if __name__ == "__main__":
     time.sleep(5)
     rclpy.init()
 
+    # Any arguments after the mode are floats passed on to the test's constructor.
+    args = [float(arg) for arg in sys.argv[2:]]
     if sys.argv[1] == "auto_gps":
-        test = TestAutoOriginFromGPSFix()
+        test = TestAutoOriginFromGPSFix(*args)
     elif sys.argv[1] == "auto_navsat":
         test = TestAutoOriginFromNavSatFix()
     elif sys.argv[1] == "invalid_gps":
@@ -318,6 +338,6 @@ if __name__ == "__main__":
     elif sys.argv[1] == "invalid_navsat":
         test = TestInvalidNavSatFix()
     elif sys.argv[1] == "manual":
-        test = TestManualOrigin()
+        test = TestManualOrigin(*args)
 
     rclpy.shutdown()


### PR DESCRIPTION
- origin_manager: publish the origin heading (degrees ENU,
  counter-clockwise from east) as the yaw of the PoseStamped
  orientation instead of always using identity, accept an optional
  "heading" key in named origins, and report the heading in
  diagnostics.
- origin_manager/initialize_origin: add local_xy_use_gpsfix_track
  (default false) parameter. When set, a GPSFix origin points the local X axis
  along the track (90 - track), but only if the track is finite and its
  uncertainty (err_track) is finite and positive; otherwise the heading
  is 0 and a warning is logged. An uncertainty of 0, which drivers leave
  when they never fill it in, is not trusted.
- initialize_origin: use the heading entry of local_xy_origins, which
  was previously required but silently dropped, and log the
  local_xy_use_gpsfix_track setting at startup.
- lat_lon_tf_echo: take the origin heading from a PoseStamped origin's
  orientation instead of assuming 0, so it agrees with LocalXyWgs84Util
  now that origins can carry a heading.


Closes #755